### PR TITLE
marc: preservation of input tag indicators

### DIFF
--- a/jsonalchemy/contrib/marc/fields/marc.cfg
+++ b/jsonalchemy/contrib/marc/fields/marc.cfg
@@ -50,7 +50,7 @@ library_of_congress_control_number:
                 ('010__z', 'canceled_invalid_lc_control_number'))
         marc, '010..', {'lc_control_number': value['a'], 'field_link_and_sequence_number': value['8'], 'nucmc_control_number': value['b'], 'canceled_invalid_lc_control_number': value['z']}
     producer:
-        json_for_marc(), {'010__a': 'lc_control_number', '010__8': 'field_link_and_sequence_number', '010__b': 'nucmc_control_number', '010__z': 'canceled_invalid_lc_control_number'}
+        json_for_marc(), {'a': 'lc_control_number', '8': 'field_link_and_sequence_number', 'b': 'nucmc_control_number', 'z': 'canceled_invalid_lc_control_number'}
 
 @extend
 patent_control_information:
@@ -66,7 +66,7 @@ patent_control_information:
                 ('013__8', 'field_link_and_sequence_number'))
         marc, '013..', {'number': value['a'], 'type_of_number': value['c'], 'country': value['b'], 'status': value['e'], 'date': value['d'], 'party_to_document': value['f'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'013__a': 'number', '013__c': 'type_of_number', '013__b': 'country', '013__e': 'status', '013__d': 'date', '013__f': 'party_to_document', '013__6': 'linkage', '013__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'number', 'c': 'type_of_number', 'b': 'country', 'e': 'status', 'd': 'date', 'f': 'party_to_document', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 national_bibliography_number:
@@ -80,7 +80,7 @@ national_bibliography_number:
                 ('015__z', 'canceled_invalid_national_bibliography_number'))
         marc, '015..', {'national_bibliography_number': value['a'], 'qualifying_information': value['q'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_national_bibliography_number': value['z']}
     producer:
-        json_for_marc(), {'015__a': 'national_bibliography_number', '015__q': 'qualifying_information', '015__2': 'source', '015__6': 'linkage', '015__8': 'field_link_and_sequence_number', '015__z': 'canceled_invalid_national_bibliography_number'}
+        json_for_marc(), {'a': 'national_bibliography_number', 'q': 'qualifying_information', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_national_bibliography_number'}
 
 @extend
 national_bibliographic_agency_control_number:
@@ -92,7 +92,7 @@ national_bibliographic_agency_control_number:
                 ('016__z', 'canceled_invalid_control_number'))
         marc, '016..', {'record_control_number': value['a'], 'field_link_and_sequence_number': value['8'], 'source': value['2'], 'canceled_invalid_control_number': value['z']}
     producer:
-        json_for_marc(), {'016__a': 'record_control_number', '016__8': 'field_link_and_sequence_number', '016__2': 'source', '016__z': 'canceled_invalid_control_number'}
+        json_for_marc(), {'a': 'record_control_number', '8': 'field_link_and_sequence_number', '2': 'source', 'z': 'canceled_invalid_control_number'}
 
 @extend
 copyright_or_legal_deposit_number:
@@ -108,7 +108,7 @@ copyright_or_legal_deposit_number:
                 ('017__z', 'canceled_invalid_copyright_or_legal_deposit_number'))
         marc, '017..', {'copyright_or_legal_deposit_number': value['a'], 'assigning_agency': value['b'], 'date': value['d'], 'display_text': value['i'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_copyright_or_legal_deposit_number': value['z']}
     producer:
-        json_for_marc(), {'017__a': 'copyright_or_legal_deposit_number', '017__b': 'assigning_agency', '017__d': 'date', '017__i': 'display_text', '017__2': 'source', '017__6': 'linkage', '017__8': 'field_link_and_sequence_number', '017__z': 'canceled_invalid_copyright_or_legal_deposit_number'}
+        json_for_marc(), {'a': 'copyright_or_legal_deposit_number', 'b': 'assigning_agency', 'd': 'date', 'i': 'display_text', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_copyright_or_legal_deposit_number'}
 
 @extend
 copyright_article_fee_code:
@@ -119,7 +119,7 @@ copyright_article_fee_code:
                 ('018__6', 'linkage'))
         marc, '018..', {'copyright_article_fee_code_nr': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'018__a': 'copyright_article_fee_code_nr', '018__8': 'field_link_and_sequence_number', '018__6': 'linkage'}
+        json_for_marc(), {'a': 'copyright_article_fee_code_nr', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 international_standard_book_number:
@@ -133,7 +133,7 @@ international_standard_book_number:
                 ('020__z', 'canceled_invalid_isbn'))
         marc, '020..', {'international_standard_book_number': value['a'], 'terms_of_availability': value['c'], 'qualifying_information': value['q'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_isbn': value['z']}
     producer:
-        json_for_marc(), {'020__a': 'international_standard_book_number', '020__c': 'terms_of_availability', '020__q': 'qualifying_information', '020__6': 'linkage', '020__8': 'field_link_and_sequence_number', '020__z': 'canceled_invalid_isbn'}
+        json_for_marc(), {'a': 'international_standard_book_number', 'c': 'terms_of_availability', 'q': 'qualifying_information', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_isbn'}
 
 @extend
 international_standard_serial_number:
@@ -149,7 +149,7 @@ international_standard_serial_number:
                 ('022__z', 'canceled_issn'))
         marc, '022..', {'international_standard_serial_number': value['a'], 'canceled_issn_l': value['m'], 'issn_l': value['l'], 'source': value['2'], 'linkage': value['6'], 'incorrect_issn': value['y'], 'field_link_and_sequence_number': value['8'], 'canceled_issn': value['z']}
     producer:
-        json_for_marc(), {'022__a': 'international_standard_serial_number', '022__m': 'canceled_issn_l', '022__l': 'issn_l', '022__2': 'source', '022__6': 'linkage', '022__y': 'incorrect_issn', '022__8': 'field_link_and_sequence_number', '022__z': 'canceled_issn'}
+        json_for_marc(), {'a': 'international_standard_serial_number', 'm': 'canceled_issn_l', 'l': 'issn_l', '2': 'source', '6': 'linkage', 'y': 'incorrect_issn', '8': 'field_link_and_sequence_number', 'z': 'canceled_issn'}
 
 @extend
 other_standard_identifier:
@@ -165,7 +165,7 @@ other_standard_identifier:
                 ('024__z', 'canceled_invalid_standard_number_or_code'))
         marc, '024..', {'standard_number_or_code': value['a'], 'terms_of_availability': value['c'], 'additional_codes_following_the_standard_number_or_code': value['d'], 'qualifying_information': value['q'], 'source_of_number_or_code': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_standard_number_or_code': value['z']}
     producer:
-        json_for_marc(), {'024__a': 'standard_number_or_code', '024__c': 'terms_of_availability', '024__d': 'additional_codes_following_the_standard_number_or_code', '024__q': 'qualifying_information', '024__2': 'source_of_number_or_code', '024__6': 'linkage', '024__8': 'field_link_and_sequence_number', '024__z': 'canceled_invalid_standard_number_or_code'}
+        json_for_marc(), {'a': 'standard_number_or_code', 'c': 'terms_of_availability', 'd': 'additional_codes_following_the_standard_number_or_code', 'q': 'qualifying_information', '2': 'source_of_number_or_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_standard_number_or_code'}
 
 @extend
 overseas_acquisition_number:
@@ -175,7 +175,7 @@ overseas_acquisition_number:
                 ('025__8', 'field_link_and_sequence_number'))
         marc, '025..', {'overseas_acquisition_number': value['a'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'025__a': 'overseas_acquisition_number', '025__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'overseas_acquisition_number', '8': 'field_link_and_sequence_number'}
 
 @extend
 fingerprint_identifier:
@@ -192,7 +192,7 @@ fingerprint_identifier:
                 ('026__8', 'field_link_and_sequence_number'))
         marc, '026..', {'first_and_second_groups_of_characters': value['a'], 'date': value['c'], 'third_and_fourth_groups_of_characters': value['b'], 'unparsed_fingerprint': value['e'], 'number_of_volume_or_part': value['d'], 'source': value['2'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'026__a': 'first_and_second_groups_of_characters', '026__c': 'date', '026__b': 'third_and_fourth_groups_of_characters', '026__e': 'unparsed_fingerprint', '026__d': 'number_of_volume_or_part', '026__2': 'source', '026__5': 'institution_to_which_field_applies', '026__6': 'linkage', '026__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'first_and_second_groups_of_characters', 'c': 'date', 'b': 'third_and_fourth_groups_of_characters', 'e': 'unparsed_fingerprint', 'd': 'number_of_volume_or_part', '2': 'source', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 standard_technical_report_number:
@@ -205,7 +205,7 @@ standard_technical_report_number:
                 ('027__6', 'linkage'))
         marc, '027..', {'standard_technical_report_number': value['a'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_number': value['z'], 'qualifying_information': value['q'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'027__a': 'standard_technical_report_number', '027__8': 'field_link_and_sequence_number', '027__z': 'canceled_invalid_number', '027__q': 'qualifying_information', '027__6': 'linkage'}
+        json_for_marc(), {'a': 'standard_technical_report_number', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_number', 'q': 'qualifying_information', '6': 'linkage'}
 
 @extend
 publisher_number:
@@ -218,7 +218,7 @@ publisher_number:
                 ('028__6', 'linkage'))
         marc, '028..', {'publisher_number': value['a'], 'field_link_and_sequence_number': value['8'], 'source': value['b'], 'qualifying_information': value['q'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'028__a': 'publisher_number', '028__8': 'field_link_and_sequence_number', '028__b': 'source', '028__q': 'qualifying_information', '028__6': 'linkage'}
+        json_for_marc(), {'a': 'publisher_number', '8': 'field_link_and_sequence_number', 'b': 'source', 'q': 'qualifying_information', '6': 'linkage'}
 
 @extend
 coden_designation:
@@ -230,7 +230,7 @@ coden_designation:
                 ('030__6', 'linkage'))
         marc, '030..', {'coden': value['a'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_coden': value['z'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'030__a': 'coden', '030__8': 'field_link_and_sequence_number', '030__z': 'canceled_invalid_coden', '030__6': 'linkage'}
+        json_for_marc(), {'a': 'coden', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_coden', '6': 'linkage'}
 
 @extend
 musical_incipits_information:
@@ -258,7 +258,7 @@ musical_incipits_information:
                 ('031__r', 'key_or_mode'))
         marc, '031..', {'number_of_work': value['a'], 'number_of_excerpt': value['c'], 'number_of_movement': value['b'], 'role': value['e'], 'caption_or_heading': value['d'], 'clef': value['g'], 'public_note': value['z'], 'voice_instrument': value['m'], 'time_signature': value['o'], 'key_signature': value['n'], 'general_note': value['q'], 'musical_notation': value['p'], 'coded_validity_note': value['s'], 'system_code': value['2'], 'uniform_resource_identifier': value['u'], 'text_incipit': value['t'], 'linkage': value['6'], 'link_text': value['y'], 'field_link_and_sequence_number': value['8'], 'key_or_mode': value['r']}
     producer:
-        json_for_marc(), {'031__a': 'number_of_work', '031__c': 'number_of_excerpt', '031__b': 'number_of_movement', '031__e': 'role', '031__d': 'caption_or_heading', '031__g': 'clef', '031__z': 'public_note', '031__m': 'voice_instrument', '031__o': 'time_signature', '031__n': 'key_signature', '031__q': 'general_note', '031__p': 'musical_notation', '031__s': 'coded_validity_note', '031__2': 'system_code', '031__u': 'uniform_resource_identifier', '031__t': 'text_incipit', '031__6': 'linkage', '031__y': 'link_text', '031__8': 'field_link_and_sequence_number', '031__r': 'key_or_mode'}
+        json_for_marc(), {'a': 'number_of_work', 'c': 'number_of_excerpt', 'b': 'number_of_movement', 'e': 'role', 'd': 'caption_or_heading', 'g': 'clef', 'z': 'public_note', 'm': 'voice_instrument', 'o': 'time_signature', 'n': 'key_signature', 'q': 'general_note', 'p': 'musical_notation', 's': 'coded_validity_note', '2': 'system_code', 'u': 'uniform_resource_identifier', 't': 'text_incipit', '6': 'linkage', 'y': 'link_text', '8': 'field_link_and_sequence_number', 'r': 'key_or_mode'}
 
 @extend
 postal_registration_number:
@@ -270,7 +270,7 @@ postal_registration_number:
                 ('032__6', 'linkage'))
         marc, '032..', {'postal_registration_number': value['a'], 'field_link_and_sequence_number': value['8'], 'source_agency_assigning_number': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'032__a': 'postal_registration_number', '032__8': 'field_link_and_sequence_number', '032__b': 'source_agency_assigning_number', '032__6': 'linkage'}
+        json_for_marc(), {'a': 'postal_registration_number', '8': 'field_link_and_sequence_number', 'b': 'source_agency_assigning_number', '6': 'linkage'}
 
 @extend
 date_time_and_place_of_an_event:
@@ -287,7 +287,7 @@ date_time_and_place_of_an_event:
                 ('033__8', 'field_link_and_sequence_number'))
         marc, '033..', {'formatted_date_time': value['a'], 'geographic_classification_subarea_code': value['c'], 'geographic_classification_area_code': value['b'], 'place_of_event': value['p'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_term': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'033__a': 'formatted_date_time', '033__c': 'geographic_classification_subarea_code', '033__b': 'geographic_classification_area_code', '033__p': 'place_of_event', '033__0': 'authority_record_control_number', '033__3': 'materials_specified', '033__2': 'source_of_term', '033__6': 'linkage', '033__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'formatted_date_time', 'c': 'geographic_classification_subarea_code', 'b': 'geographic_classification_area_code', 'p': 'place_of_event', '0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_term', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 coded_cartographic_mathematical_data:
@@ -319,7 +319,7 @@ coded_cartographic_mathematical_data:
                 ('034__z', 'name_of_extraterrestrial_body'))
         marc, '034..', {'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'category_of_scale': value['a'], 'constant_ratio_linear_vertical_scale': value['c'], 'constant_ratio_linear_horizontal_scale': value['b'], 'coordinates_easternmost_longitude': value['e'], 'coordinates_westernmost_longitude': value['d'], 'coordinates_southernmost_latitude': value['g'], 'coordinates_northernmost_latitude': value['f'], 'angular_scale': value['h'], 'declination_southern_limit': value['k'], 'declination_northern_limit': value['j'], 'right_ascension_eastern_limit': value['m'], 'right_ascension_western_limit': value['n'], 'equinox': value['p'], 'g_ring_latitude': value['s'], 'distance_from_earth': value['r'], 'g_ring_longitude': value['t'], 'ending_date': value['y'], 'beginning_date': value['x'], 'name_of_extraterrestrial_body': value['z']}
     producer:
-        json_for_marc(), {'034__0': 'authority_record_control_number_or_standard_number', '034__3': 'materials_specified', '034__2': 'source', '034__6': 'linkage', '034__8': 'field_link_and_sequence_number', '034__a': 'category_of_scale', '034__c': 'constant_ratio_linear_vertical_scale', '034__b': 'constant_ratio_linear_horizontal_scale', '034__e': 'coordinates_easternmost_longitude', '034__d': 'coordinates_westernmost_longitude', '034__g': 'coordinates_southernmost_latitude', '034__f': 'coordinates_northernmost_latitude', '034__h': 'angular_scale', '034__k': 'declination_southern_limit', '034__j': 'declination_northern_limit', '034__m': 'right_ascension_eastern_limit', '034__n': 'right_ascension_western_limit', '034__p': 'equinox', '034__s': 'g_ring_latitude', '034__r': 'distance_from_earth', '034__t': 'g_ring_longitude', '034__y': 'ending_date', '034__x': 'beginning_date', '034__z': 'name_of_extraterrestrial_body'}
+        json_for_marc(), {'0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'category_of_scale', 'c': 'constant_ratio_linear_vertical_scale', 'b': 'constant_ratio_linear_horizontal_scale', 'e': 'coordinates_easternmost_longitude', 'd': 'coordinates_westernmost_longitude', 'g': 'coordinates_southernmost_latitude', 'f': 'coordinates_northernmost_latitude', 'h': 'angular_scale', 'k': 'declination_southern_limit', 'j': 'declination_northern_limit', 'm': 'right_ascension_eastern_limit', 'n': 'right_ascension_western_limit', 'p': 'equinox', 's': 'g_ring_latitude', 'r': 'distance_from_earth', 't': 'g_ring_longitude', 'y': 'ending_date', 'x': 'beginning_date', 'z': 'name_of_extraterrestrial_body'}
 
 @extend
 system_control_number:
@@ -331,7 +331,7 @@ system_control_number:
                 ('035__6', 'linkage'))
         marc, '035..', {'system_control_number': value['a'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_control_number': value['z'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'035__a': 'system_control_number', '035__8': 'field_link_and_sequence_number', '035__z': 'canceled_invalid_control_number', '035__6': 'linkage'}
+        json_for_marc(), {'a': 'system_control_number', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_control_number', '6': 'linkage'}
 
 @extend
 original_study_number_for_computer_data_files:
@@ -343,7 +343,7 @@ original_study_number_for_computer_data_files:
                 ('036__6', 'linkage'))
         marc, '036..', {'original_study_number': value['a'], 'field_link_and_sequence_number': value['8'], 'source_agency_assigning_number': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'036__a': 'original_study_number', '036__8': 'field_link_and_sequence_number', '036__b': 'source_agency_assigning_number', '036__6': 'linkage'}
+        json_for_marc(), {'a': 'original_study_number', '8': 'field_link_and_sequence_number', 'b': 'source_agency_assigning_number', '6': 'linkage'}
 
 @extend
 source_of_acquisition:
@@ -359,7 +359,7 @@ source_of_acquisition:
                 ('037__8', 'field_link_and_sequence_number'))
         marc, '037..', {'stock_number': value['a'], 'terms_of_availability': value['c'], 'source_of_stock_number_acquisition': value['b'], 'additional_format_characteristics': value['g'], 'form_of_issue': value['f'], 'note': value['n'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'037__a': 'stock_number', '037__c': 'terms_of_availability', '037__b': 'source_of_stock_number_acquisition', '037__g': 'additional_format_characteristics', '037__f': 'form_of_issue', '037__n': 'note', '037__6': 'linkage', '037__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'stock_number', 'c': 'terms_of_availability', 'b': 'source_of_stock_number_acquisition', 'g': 'additional_format_characteristics', 'f': 'form_of_issue', 'n': 'note', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 record_content_licensor:
@@ -370,7 +370,7 @@ record_content_licensor:
                 ('038__6', 'linkage'))
         marc, '038..', {'record_content_licensor': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'038__a': 'record_content_licensor', '038__8': 'field_link_and_sequence_number', '038__6': 'linkage'}
+        json_for_marc(), {'a': 'record_content_licensor', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 cataloging_source:
@@ -385,7 +385,7 @@ cataloging_source:
                 ('040__8', 'field_link_and_sequence_number'))
         marc, '040..', {'original_cataloging_agency': value['a'], 'transcribing_agency': value['c'], 'language_of_cataloging': value['b'], 'description_conventions': value['e'], 'modifying_agency': value['d'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'040__a': 'original_cataloging_agency', '040__c': 'transcribing_agency', '040__b': 'language_of_cataloging', '040__e': 'description_conventions', '040__d': 'modifying_agency', '040__6': 'linkage', '040__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'original_cataloging_agency', 'c': 'transcribing_agency', 'b': 'language_of_cataloging', 'e': 'description_conventions', 'd': 'modifying_agency', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 language_code:
@@ -407,7 +407,7 @@ language_code:
                 ('041__8', 'field_link_and_sequence_number'))
         marc, '041..', {'language_code_of_text_sound_track_or_separate_title': value['a'], 'language_code_of_summary_or_abstract': value['b'], 'language_code_of_librettos': value['e'], 'language_code_of_sung_or_spoken_text': value['d'], 'language_code_of_accompanying_material_other_than_librettos': value['g'], 'language_code_of_table_of_contents': value['f'], 'language_code_of_original': value['h'], 'language_code_of_intermediate_translations': value['k'], 'language_code_of_subtitles_or_captions': value['j'], 'language_code_of_original_accompanying_materials_other_than_librettos': value['m'], 'language_code_of_original_libretto': value['n'], 'source_of_code': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'041__a': 'language_code_of_text_sound_track_or_separate_title', '041__b': 'language_code_of_summary_or_abstract', '041__e': 'language_code_of_librettos', '041__d': 'language_code_of_sung_or_spoken_text', '041__g': 'language_code_of_accompanying_material_other_than_librettos', '041__f': 'language_code_of_table_of_contents', '041__h': 'language_code_of_original', '041__k': 'language_code_of_intermediate_translations', '041__j': 'language_code_of_subtitles_or_captions', '041__m': 'language_code_of_original_accompanying_materials_other_than_librettos', '041__n': 'language_code_of_original_libretto', '041__2': 'source_of_code', '041__6': 'linkage', '041__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'language_code_of_text_sound_track_or_separate_title', 'b': 'language_code_of_summary_or_abstract', 'e': 'language_code_of_librettos', 'd': 'language_code_of_sung_or_spoken_text', 'g': 'language_code_of_accompanying_material_other_than_librettos', 'f': 'language_code_of_table_of_contents', 'h': 'language_code_of_original', 'k': 'language_code_of_intermediate_translations', 'j': 'language_code_of_subtitles_or_captions', 'm': 'language_code_of_original_accompanying_materials_other_than_librettos', 'n': 'language_code_of_original_libretto', '2': 'source_of_code', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 authentication_code:
@@ -416,7 +416,7 @@ authentication_code:
                 ('042__a', 'authentication_code'))
         marc, '042..', {'authentication_code': value['a']}
     producer:
-        json_for_marc(), {'042__a': 'authentication_code'}
+        json_for_marc(), {'a': 'authentication_code'}
 
 @extend
 geographic_area_code:
@@ -431,7 +431,7 @@ geographic_area_code:
                 ('043__8', 'field_link_and_sequence_number'))
         marc, '043..', {'geographic_area_code': value['a'], 'iso_code': value['c'], 'local_gac_code': value['b'], 'authority_record_control_number_or_standard_number': value['0'], 'source_of_local_code': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'043__a': 'geographic_area_code', '043__c': 'iso_code', '043__b': 'local_gac_code', '043__0': 'authority_record_control_number_or_standard_number', '043__2': 'source_of_local_code', '043__6': 'linkage', '043__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'geographic_area_code', 'c': 'iso_code', 'b': 'local_gac_code', '0': 'authority_record_control_number_or_standard_number', '2': 'source_of_local_code', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 country_of_publishing_producing_entity_code:
@@ -445,7 +445,7 @@ country_of_publishing_producing_entity_code:
                 ('044__8', 'field_link_and_sequence_number'))
         marc, '044..', {'marc_country_code': value['a'], 'iso_country_code': value['c'], 'local_subentity_code': value['b'], 'source_of_local_subentity_code': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'044__a': 'marc_country_code', '044__c': 'iso_country_code', '044__b': 'local_subentity_code', '044__2': 'source_of_local_subentity_code', '044__6': 'linkage', '044__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'marc_country_code', 'c': 'iso_country_code', 'b': 'local_subentity_code', '2': 'source_of_local_subentity_code', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 time_period_of_content:
@@ -458,7 +458,7 @@ time_period_of_content:
                 ('045__6', 'linkage'))
         marc, '045..', {'time_period_code': value['a'], 'field_link_and_sequence_number': value['8'], 'formatted_pre_9999_bc_time_period': value['c'], 'formatted_9999_bc_through_ce_time_period': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'045__a': 'time_period_code', '045__8': 'field_link_and_sequence_number', '045__c': 'formatted_pre_9999_bc_time_period', '045__b': 'formatted_9999_bc_through_ce_time_period', '045__6': 'linkage'}
+        json_for_marc(), {'a': 'time_period_code', '8': 'field_link_and_sequence_number', 'c': 'formatted_pre_9999_bc_time_period', 'b': 'formatted_9999_bc_through_ce_time_period', '6': 'linkage'}
 
 @extend
 special_coded_dates:
@@ -481,7 +481,7 @@ special_coded_dates:
                 ('046__8', 'field_link_and_sequence_number'))
         marc, '046..', {'type_of_date_code': value['a'], 'date_1_ce_date': value['c'], 'date_1_bc_date': value['b'], 'date_2_ce_date': value['e'], 'date_2_bc_date': value['d'], 'beginning_or_single_date_created': value['k'], 'date_resource_modified': value['j'], 'beginning_of_date_valid': value['m'], 'ending_date_created': value['l'], 'single_or_starting_date_for_aggregated_content': value['o'], 'end_of_date_valid': value['n'], 'ending_date_for_aggregated_content': value['p'], 'source_of_date': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'046__a': 'type_of_date_code', '046__c': 'date_1_ce_date', '046__b': 'date_1_bc_date', '046__e': 'date_2_ce_date', '046__d': 'date_2_bc_date', '046__k': 'beginning_or_single_date_created', '046__j': 'date_resource_modified', '046__m': 'beginning_of_date_valid', '046__l': 'ending_date_created', '046__o': 'single_or_starting_date_for_aggregated_content', '046__n': 'end_of_date_valid', '046__p': 'ending_date_for_aggregated_content', '046__2': 'source_of_date', '046__6': 'linkage', '046__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'type_of_date_code', 'c': 'date_1_ce_date', 'b': 'date_1_bc_date', 'e': 'date_2_ce_date', 'd': 'date_2_bc_date', 'k': 'beginning_or_single_date_created', 'j': 'date_resource_modified', 'm': 'beginning_of_date_valid', 'l': 'ending_date_created', 'o': 'single_or_starting_date_for_aggregated_content', 'n': 'end_of_date_valid', 'p': 'ending_date_for_aggregated_content', '2': 'source_of_date', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 form_of_musical_composition_code:
@@ -492,7 +492,7 @@ form_of_musical_composition_code:
                 ('047__2', 'source_of_code'))
         marc, '047..', {'form_of_musical_composition_code': value['a'], 'field_link_and_sequence_number': value['8'], 'source_of_code': value['2']}
     producer:
-        json_for_marc(), {'047__a': 'form_of_musical_composition_code', '047__8': 'field_link_and_sequence_number', '047__2': 'source_of_code'}
+        json_for_marc(), {'a': 'form_of_musical_composition_code', '8': 'field_link_and_sequence_number', '2': 'source_of_code'}
 
 @extend
 number_of_musical_instruments_or_voices_code:
@@ -504,7 +504,7 @@ number_of_musical_instruments_or_voices_code:
                 ('048__b', 'soloist'))
         marc, '048..', {'performer_or_ensemble': value['a'], 'field_link_and_sequence_number': value['8'], 'source_of_code': value['2'], 'soloist': value['b']}
     producer:
-        json_for_marc(), {'048__a': 'performer_or_ensemble', '048__8': 'field_link_and_sequence_number', '048__2': 'source_of_code', '048__b': 'soloist'}
+        json_for_marc(), {'a': 'performer_or_ensemble', '8': 'field_link_and_sequence_number', '2': 'source_of_code', 'b': 'soloist'}
 
 @extend
 library_of_congress_call_number:
@@ -517,7 +517,7 @@ library_of_congress_call_number:
                 ('050__6', 'linkage'))
         marc, '050..', {'classification_number': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'item_number': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'050__a': 'classification_number', '050__8': 'field_link_and_sequence_number', '050__3': 'materials_specified', '050__b': 'item_number', '050__6': 'linkage'}
+        json_for_marc(), {'a': 'classification_number', '8': 'field_link_and_sequence_number', '3': 'materials_specified', 'b': 'item_number', '6': 'linkage'}
 
 @extend
 library_of_congress_copy_issue_offprint_statement:
@@ -529,7 +529,7 @@ library_of_congress_copy_issue_offprint_statement:
                 ('051__b', 'item_number'))
         marc, '051..', {'classification_number': value['a'], 'field_link_and_sequence_number': value['8'], 'copy_information': value['c'], 'item_number': value['b']}
     producer:
-        json_for_marc(), {'051__a': 'classification_number', '051__8': 'field_link_and_sequence_number', '051__c': 'copy_information', '051__b': 'item_number'}
+        json_for_marc(), {'a': 'classification_number', '8': 'field_link_and_sequence_number', 'c': 'copy_information', 'b': 'item_number'}
 
 @extend
 geographic_classification:
@@ -543,7 +543,7 @@ geographic_classification:
                 ('052__8', 'field_link_and_sequence_number'))
         marc, '052..', {'geographic_classification_area_code': value['a'], 'geographic_classification_subarea_code': value['b'], 'populated_place_name': value['d'], 'code_source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'052__a': 'geographic_classification_area_code', '052__b': 'geographic_classification_subarea_code', '052__d': 'populated_place_name', '052__2': 'code_source', '052__6': 'linkage', '052__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'geographic_classification_area_code', 'b': 'geographic_classification_subarea_code', 'd': 'populated_place_name', '2': 'code_source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 classification_numbers_assigned_in_canada:
@@ -556,7 +556,7 @@ classification_numbers_assigned_in_canada:
                 ('055__6', 'linkage'))
         marc, '055..', {'classification_number': value['a'], 'field_link_and_sequence_number': value['8'], 'source_of_call_class_number': value['2'], 'item_number': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'055__a': 'classification_number', '055__8': 'field_link_and_sequence_number', '055__2': 'source_of_call_class_number', '055__b': 'item_number', '055__6': 'linkage'}
+        json_for_marc(), {'a': 'classification_number', '8': 'field_link_and_sequence_number', '2': 'source_of_call_class_number', 'b': 'item_number', '6': 'linkage'}
 
 @extend
 national_library_of_medicine_call_number:
@@ -567,7 +567,7 @@ national_library_of_medicine_call_number:
                 ('060__b', 'item_number'))
         marc, '060..', {'classification_number_r': value['a'], 'field_link_and_sequence_number': value['8'], 'item_number': value['b']}
     producer:
-        json_for_marc(), {'060__a': 'classification_number_r', '060__8': 'field_link_and_sequence_number', '060__b': 'item_number'}
+        json_for_marc(), {'a': 'classification_number_r', '8': 'field_link_and_sequence_number', 'b': 'item_number'}
 
 @extend
 national_library_of_medicine_copy_statement:
@@ -579,7 +579,7 @@ national_library_of_medicine_copy_statement:
                 ('061__b', 'item_number'))
         marc, '061..', {'classification_number': value['a'], 'field_link_and_sequence_number': value['8'], 'copy_information': value['c'], 'item_number': value['b']}
     producer:
-        json_for_marc(), {'061__a': 'classification_number', '061__8': 'field_link_and_sequence_number', '061__c': 'copy_information', '061__b': 'item_number'}
+        json_for_marc(), {'a': 'classification_number', '8': 'field_link_and_sequence_number', 'c': 'copy_information', 'b': 'item_number'}
 
 @extend
 character_sets_present:
@@ -590,7 +590,7 @@ character_sets_present:
                 ('066__b', 'primary_g1_character_set'))
         marc, '066..', {'primary_g0_character_set': value['a'], 'alternate_g0_or_g1_character_set': value['c'], 'primary_g1_character_set': value['b']}
     producer:
-        json_for_marc(), {'066__a': 'primary_g0_character_set', '066__c': 'alternate_g0_or_g1_character_set', '066__b': 'primary_g1_character_set'}
+        json_for_marc(), {'a': 'primary_g0_character_set', 'c': 'alternate_g0_or_g1_character_set', 'b': 'primary_g1_character_set'}
 
 @extend
 national_agricultural_library_call_number:
@@ -601,7 +601,7 @@ national_agricultural_library_call_number:
                 ('070__b', 'item_number'))
         marc, '070..', {'classification_number': value['a'], 'field_link_and_sequence_number_r': value['8'], 'item_number': value['b']}
     producer:
-        json_for_marc(), {'070__a': 'classification_number', '070__8': 'field_link_and_sequence_number_r', '070__b': 'item_number'}
+        json_for_marc(), {'a': 'classification_number', '8': 'field_link_and_sequence_number_r', 'b': 'item_number'}
 
 @extend
 national_agricultural_library_copy_statement:
@@ -613,7 +613,7 @@ national_agricultural_library_copy_statement:
                 ('071__b', 'item_number'))
         marc, '071..', {'classification_number': value['a'], 'field_link_and_sequence_number': value['8'], 'copy_information': value['c'], 'item_number': value['b']}
     producer:
-        json_for_marc(), {'071__a': 'classification_number', '071__8': 'field_link_and_sequence_number', '071__c': 'copy_information', '071__b': 'item_number'}
+        json_for_marc(), {'a': 'classification_number', '8': 'field_link_and_sequence_number', 'c': 'copy_information', 'b': 'item_number'}
 
 @extend
 subject_category_code:
@@ -626,7 +626,7 @@ subject_category_code:
                 ('072__6', 'linkage'))
         marc, '072..', {'subject_category_code': value['a'], 'field_link_and_sequence_number': value['8'], 'source': value['2'], 'subject_category_code_subdivision': value['x'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'072__a': 'subject_category_code', '072__8': 'field_link_and_sequence_number', '072__2': 'source', '072__x': 'subject_category_code_subdivision', '072__6': 'linkage'}
+        json_for_marc(), {'a': 'subject_category_code', '8': 'field_link_and_sequence_number', '2': 'source', 'x': 'subject_category_code_subdivision', '6': 'linkage'}
 
 @extend
 gpo_item_number:
@@ -637,7 +637,7 @@ gpo_item_number:
                 ('074__z', 'canceled_invalid_gpo_item_number'))
         marc, '074..', {'gpo_item_number': value['a'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_gpo_item_number': value['z']}
     producer:
-        json_for_marc(), {'074__a': 'gpo_item_number', '074__8': 'field_link_and_sequence_number', '074__z': 'canceled_invalid_gpo_item_number'}
+        json_for_marc(), {'a': 'gpo_item_number', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_gpo_item_number'}
 
 @extend
 universal_decimal_classification_number:
@@ -651,7 +651,7 @@ universal_decimal_classification_number:
                 ('080__8', 'field_link_and_sequence_number'))
         marc, '080..', {'universal_decimal_classification_number': value['a'], 'item_number': value['b'], 'linkage': value['6'], 'edition_identifier': value['2'], 'common_auxiliary_subdivision': value['x'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'080__a': 'universal_decimal_classification_number', '080__b': 'item_number', '080__6': 'linkage', '080__2': 'edition_identifier', '080__x': 'common_auxiliary_subdivision', '080__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'universal_decimal_classification_number', 'b': 'item_number', '6': 'linkage', '2': 'edition_identifier', 'x': 'common_auxiliary_subdivision', '8': 'field_link_and_sequence_number'}
 
 @extend
 dewey_decimal_classification_number:
@@ -666,7 +666,7 @@ dewey_decimal_classification_number:
                 ('082__8', 'field_link_and_sequence_number'))
         marc, '082..', {'classification_number': value['a'], 'item_number': value['b'], 'standard_or_optional_designation': value['m'], 'assigning_agency': value['q'], 'edition_number': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'082__a': 'classification_number', '082__b': 'item_number', '082__m': 'standard_or_optional_designation', '082__q': 'assigning_agency', '082__2': 'edition_number', '082__6': 'linkage', '082__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'classification_number', 'b': 'item_number', 'm': 'standard_or_optional_designation', 'q': 'assigning_agency', '2': 'edition_number', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 additional_dewey_decimal_classification_number:
@@ -683,7 +683,7 @@ additional_dewey_decimal_classification_number:
                 ('083__z', 'table_identification'))
         marc, '083..', {'classification_number': value['a'], 'classification_number_ending_number_of_span': value['c'], 'standard_or_optional_designation': value['m'], 'assigning_agency': value['q'], 'edition_number': value['2'], 'linkage': value['6'], 'table_sequence_number_for_internal_subarrangement_or_add_table': value['y'], 'field_link_and_sequence_number': value['8'], 'table_identification': value['z']}
     producer:
-        json_for_marc(), {'083__a': 'classification_number', '083__c': 'classification_number_ending_number_of_span', '083__m': 'standard_or_optional_designation', '083__q': 'assigning_agency', '083__2': 'edition_number', '083__6': 'linkage', '083__y': 'table_sequence_number_for_internal_subarrangement_or_add_table', '083__8': 'field_link_and_sequence_number', '083__z': 'table_identification'}
+        json_for_marc(), {'a': 'classification_number', 'c': 'classification_number_ending_number_of_span', 'm': 'standard_or_optional_designation', 'q': 'assigning_agency', '2': 'edition_number', '6': 'linkage', 'y': 'table_sequence_number_for_internal_subarrangement_or_add_table', '8': 'field_link_and_sequence_number', 'z': 'table_identification'}
 
 @extend
 other_classification_number:
@@ -697,7 +697,7 @@ other_classification_number:
                 ('084__8', 'field_link_and_sequence_number'))
         marc, '084..', {'classification_number': value['a'], 'item_number': value['b'], 'assigning_agency': value['q'], 'number_source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'084__a': 'classification_number', '084__b': 'item_number', '084__q': 'assigning_agency', '084__2': 'number_source', '084__6': 'linkage', '084__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'classification_number', 'b': 'item_number', 'q': 'assigning_agency', '2': 'number_source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 synthesized_classification_number_components:
@@ -719,7 +719,7 @@ synthesized_classification_number_components:
                 ('085__z', 'table_identification'))
         marc, '085..', {'number_where_instructions_are_found_single_number_or_beginning_number_of_span': value['a'], 'classification_number_ending_number_of_span': value['c'], 'base_number': value['b'], 'facet_designator': value['f'], 'number_in_internal_subarrangement_or_add_table_where_instructions_are_found': value['v'], 'digits_added_from_classification_number_in_schedule_or_external_table': value['s'], 'root_number': value['r'], 'number_being_analyzed': value['u'], 'digits_added_from_internal_subarrangement_or_add_table': value['t'], 'table_identification_internal_subarrangement_or_add_table': value['w'], 'linkage': value['6'], 'table_sequence_number_for_internal_subarrangement_or_add_table': value['y'], 'field_link_and_sequence_number': value['8'], 'table_identification': value['z']}
     producer:
-        json_for_marc(), {'085__a': 'number_where_instructions_are_found_single_number_or_beginning_number_of_span', '085__c': 'classification_number_ending_number_of_span', '085__b': 'base_number', '085__f': 'facet_designator', '085__v': 'number_in_internal_subarrangement_or_add_table_where_instructions_are_found', '085__s': 'digits_added_from_classification_number_in_schedule_or_external_table', '085__r': 'root_number', '085__u': 'number_being_analyzed', '085__t': 'digits_added_from_internal_subarrangement_or_add_table', '085__w': 'table_identification_internal_subarrangement_or_add_table', '085__6': 'linkage', '085__y': 'table_sequence_number_for_internal_subarrangement_or_add_table', '085__8': 'field_link_and_sequence_number', '085__z': 'table_identification'}
+        json_for_marc(), {'a': 'number_where_instructions_are_found_single_number_or_beginning_number_of_span', 'c': 'classification_number_ending_number_of_span', 'b': 'base_number', 'f': 'facet_designator', 'v': 'number_in_internal_subarrangement_or_add_table_where_instructions_are_found', 's': 'digits_added_from_classification_number_in_schedule_or_external_table', 'r': 'root_number', 'u': 'number_being_analyzed', 't': 'digits_added_from_internal_subarrangement_or_add_table', 'w': 'table_identification_internal_subarrangement_or_add_table', '6': 'linkage', 'y': 'table_sequence_number_for_internal_subarrangement_or_add_table', '8': 'field_link_and_sequence_number', 'z': 'table_identification'}
 
 @extend
 government_document_classification_number:
@@ -732,7 +732,7 @@ government_document_classification_number:
                 ('086__6', 'linkage'))
         marc, '086..', {'classification_number': value['a'], 'field_link_and_sequence_number': value['8'], 'number_source': value['2'], 'canceled_invalid_classification_number': value['z'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'086__a': 'classification_number', '086__8': 'field_link_and_sequence_number', '086__2': 'number_source', '086__z': 'canceled_invalid_classification_number', '086__6': 'linkage'}
+        json_for_marc(), {'a': 'classification_number', '8': 'field_link_and_sequence_number', '2': 'number_source', 'z': 'canceled_invalid_classification_number', '6': 'linkage'}
 
 @extend
 report_number:
@@ -744,7 +744,7 @@ report_number:
                 ('088__6', 'linkage'))
         marc, '088..', {'report_number': value['a'], 'field_link_and_sequence_number': value['8'], 'canceled_invalid_report_number': value['z'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'088__a': 'report_number', '088__8': 'field_link_and_sequence_number', '088__z': 'canceled_invalid_report_number', '088__6': 'linkage'}
+        json_for_marc(), {'a': 'report_number', '8': 'field_link_and_sequence_number', 'z': 'canceled_invalid_report_number', '6': 'linkage'}
 
 @extend
 main_entry_personal_name:
@@ -771,7 +771,7 @@ main_entry_personal_name:
                 ('100__t', 'title_of_a_work'))
         marc, '100..', {'personal_name': value['a'], 'titles_and_words_associated_with_a_name': value['c'], 'numeration': value['b'], 'relator_term': value['e'], 'dates_associated_with_a_name': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'form_subheading': value['k'], 'attribution_qualifier': value['j'], 'language_of_a_work': value['l'], 'name_of_part_section_of_a_work': value['p'], 'number_of_part_section_of_a_work': value['n'], 'fuller_form_of_name': value['q'], 'authority_record_control_number': value['0'], 'affiliation': value['u'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'title_of_a_work': value['t']}
     producer:
-        json_for_marc(), {'100__a': 'personal_name', '100__c': 'titles_and_words_associated_with_a_name', '100__b': 'numeration', '100__e': 'relator_term', '100__d': 'dates_associated_with_a_name', '100__g': 'miscellaneous_information', '100__f': 'date_of_a_work', '100__k': 'form_subheading', '100__j': 'attribution_qualifier', '100__l': 'language_of_a_work', '100__p': 'name_of_part_section_of_a_work', '100__n': 'number_of_part_section_of_a_work', '100__q': 'fuller_form_of_name', '100__0': 'authority_record_control_number', '100__u': 'affiliation', '100__4': 'relator_code', '100__6': 'linkage', '100__8': 'field_link_and_sequence_number', '100__t': 'title_of_a_work'}
+        json_for_marc(), {'a': 'personal_name', 'c': 'titles_and_words_associated_with_a_name', 'b': 'numeration', 'e': 'relator_term', 'd': 'dates_associated_with_a_name', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'k': 'form_subheading', 'j': 'attribution_qualifier', 'l': 'language_of_a_work', 'p': 'name_of_part_section_of_a_work', 'n': 'number_of_part_section_of_a_work', 'q': 'fuller_form_of_name', '0': 'authority_record_control_number', 'u': 'affiliation', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 't': 'title_of_a_work'}
 
 @extend
 main_entry_corporate_name:
@@ -796,7 +796,7 @@ main_entry_corporate_name:
                 ('110__t', 'title_of_a_work'))
         marc, '110..', {'corporate_name_or_jurisdiction_name_as_entry_element': value['a'], 'location_of_meeting': value['c'], 'subordinate_unit': value['b'], 'relator_term': value['e'], 'date_of_meeting_or_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'form_subheading': value['k'], 'language_of_a_work': value['l'], 'name_of_part_section_of_a_work': value['p'], 'number_of_part_section_meeting': value['n'], 'authority_record_control_number': value['0'], 'affiliation': value['u'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number_r': value['8'], 'title_of_a_work': value['t']}
     producer:
-        json_for_marc(), {'110__a': 'corporate_name_or_jurisdiction_name_as_entry_element', '110__c': 'location_of_meeting', '110__b': 'subordinate_unit', '110__e': 'relator_term', '110__d': 'date_of_meeting_or_treaty_signing', '110__g': 'miscellaneous_information', '110__f': 'date_of_a_work', '110__k': 'form_subheading', '110__l': 'language_of_a_work', '110__p': 'name_of_part_section_of_a_work', '110__n': 'number_of_part_section_meeting', '110__0': 'authority_record_control_number', '110__u': 'affiliation', '110__4': 'relator_code', '110__6': 'linkage', '110__8': 'field_link_and_sequence_number_r', '110__t': 'title_of_a_work'}
+        json_for_marc(), {'a': 'corporate_name_or_jurisdiction_name_as_entry_element', 'c': 'location_of_meeting', 'b': 'subordinate_unit', 'e': 'relator_term', 'd': 'date_of_meeting_or_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'k': 'form_subheading', 'l': 'language_of_a_work', 'p': 'name_of_part_section_of_a_work', 'n': 'number_of_part_section_meeting', '0': 'authority_record_control_number', 'u': 'affiliation', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number_r', 't': 'title_of_a_work'}
 
 @extend
 main_entry_meeting_name:
@@ -822,7 +822,7 @@ main_entry_meeting_name:
                 ('111__t', 'title_of_a_work'))
         marc, '111..', {'meeting_name_or_jurisdiction_name_as_entry_element': value['a'], 'location_of_meeting': value['c'], 'subordinate_unit': value['e'], 'date_of_meeting': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'form_subheading': value['k'], 'relator_term': value['j'], 'language_of_a_work': value['l'], 'name_of_part_section_of_a_work': value['p'], 'number_of_part_section_meeting': value['n'], 'name_of_meeting_following_jurisdiction_name_entry_element': value['q'], 'authority_record_control_number': value['0'], 'affiliation': value['u'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'title_of_a_work': value['t']}
     producer:
-        json_for_marc(), {'111__a': 'meeting_name_or_jurisdiction_name_as_entry_element', '111__c': 'location_of_meeting', '111__e': 'subordinate_unit', '111__d': 'date_of_meeting', '111__g': 'miscellaneous_information', '111__f': 'date_of_a_work', '111__k': 'form_subheading', '111__j': 'relator_term', '111__l': 'language_of_a_work', '111__p': 'name_of_part_section_of_a_work', '111__n': 'number_of_part_section_meeting', '111__q': 'name_of_meeting_following_jurisdiction_name_entry_element', '111__0': 'authority_record_control_number', '111__u': 'affiliation', '111__4': 'relator_code', '111__6': 'linkage', '111__8': 'field_link_and_sequence_number', '111__t': 'title_of_a_work'}
+        json_for_marc(), {'a': 'meeting_name_or_jurisdiction_name_as_entry_element', 'c': 'location_of_meeting', 'e': 'subordinate_unit', 'd': 'date_of_meeting', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'k': 'form_subheading', 'j': 'relator_term', 'l': 'language_of_a_work', 'p': 'name_of_part_section_of_a_work', 'n': 'number_of_part_section_meeting', 'q': 'name_of_meeting_following_jurisdiction_name_entry_element', '0': 'authority_record_control_number', 'u': 'affiliation', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 't': 'title_of_a_work'}
 
 @extend
 main_entry_uniform_title:
@@ -847,7 +847,7 @@ main_entry_uniform_title:
                 ('130__8', 'field_link_and_sequence_number'))
         marc, '130..', {'uniform_title': value['a'], 'name_of_part_section_of_a_work': value['p'], 'date_of_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'authority_record_control_number': value['0'], 'version': value['s'], 'key_for_music': value['r'], 'title_of_a_work': value['t'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'130__a': 'uniform_title', '130__p': 'name_of_part_section_of_a_work', '130__d': 'date_of_treaty_signing', '130__g': 'miscellaneous_information', '130__f': 'date_of_a_work', '130__h': 'medium', '130__k': 'form_subheading', '130__m': 'medium_of_performance_for_music', '130__l': 'language_of_a_work', '130__o': 'arranged_statement_for_music', '130__n': 'number_of_part_section_of_a_work', '130__0': 'authority_record_control_number', '130__s': 'version', '130__r': 'key_for_music', '130__t': 'title_of_a_work', '130__6': 'linkage', '130__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'uniform_title', 'p': 'name_of_part_section_of_a_work', 'd': 'date_of_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', '0': 'authority_record_control_number', 's': 'version', 'r': 'key_for_music', 't': 'title_of_a_work', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 abbreviated_title:
@@ -860,7 +860,7 @@ abbreviated_title:
                 ('210__6', 'linkage'))
         marc, '210..', {'abbreviated_title': value['a'], 'field_link_and_sequence_number': value['8'], 'source': value['2'], 'qualifying_information': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'210__a': 'abbreviated_title', '210__8': 'field_link_and_sequence_number', '210__2': 'source', '210__b': 'qualifying_information', '210__6': 'linkage'}
+        json_for_marc(), {'a': 'abbreviated_title', '8': 'field_link_and_sequence_number', '2': 'source', 'b': 'qualifying_information', '6': 'linkage'}
 
 @extend
 key_title:
@@ -872,7 +872,7 @@ key_title:
                 ('222__6', 'linkage'))
         marc, '222..', {'key_title': value['a'], 'field_link_and_sequence_number': value['8'], 'qualifying_information': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'222__a': 'key_title', '222__8': 'field_link_and_sequence_number', '222__b': 'qualifying_information', '222__6': 'linkage'}
+        json_for_marc(), {'a': 'key_title', '8': 'field_link_and_sequence_number', 'b': 'qualifying_information', '6': 'linkage'}
 
 @extend
 uniform_title:
@@ -896,7 +896,7 @@ uniform_title:
                 ('240__8', 'field_link_and_sequence_number'))
         marc, '240..', {'uniform_title': value['a'], 'name_of_part_section_of_a_work': value['p'], 'date_of_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'authority_record_control_number': value['0'], 'version': value['s'], 'key_for_music': value['r'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'240__a': 'uniform_title', '240__p': 'name_of_part_section_of_a_work', '240__d': 'date_of_treaty_signing', '240__g': 'miscellaneous_information', '240__f': 'date_of_a_work', '240__h': 'medium', '240__k': 'form_subheading', '240__m': 'medium_of_performance_for_music', '240__l': 'language_of_a_work', '240__o': 'arranged_statement_for_music', '240__n': 'number_of_part_section_of_a_work', '240__0': 'authority_record_control_number', '240__s': 'version', '240__r': 'key_for_music', '240__6': 'linkage', '240__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'uniform_title', 'p': 'name_of_part_section_of_a_work', 'd': 'date_of_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', '0': 'authority_record_control_number', 's': 'version', 'r': 'key_for_music', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 translation_of_title_by_cataloging_agency:
@@ -913,7 +913,7 @@ translation_of_title_by_cataloging_agency:
                 ('242__8', 'field_link_and_sequence_number'))
         marc, '242..', {'title': value['a'], 'statement_of_responsibility_': value['c'], 'remainder_of_title': value['b'], 'medium': value['h'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'linkage': value['6'], 'language_code_of_translated_title': value['y'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'242__a': 'title', '242__c': 'statement_of_responsibility_', '242__b': 'remainder_of_title', '242__h': 'medium', '242__n': 'number_of_part_section_of_a_work', '242__p': 'name_of_part_section_of_a_work', '242__6': 'linkage', '242__y': 'language_code_of_translated_title', '242__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'title', 'c': 'statement_of_responsibility_', 'b': 'remainder_of_title', 'h': 'medium', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', '6': 'linkage', 'y': 'language_code_of_translated_title', '8': 'field_link_and_sequence_number'}
 
 @extend
 collective_uniform_title:
@@ -936,7 +936,7 @@ collective_uniform_title:
                 ('243__8', 'field_link_and_sequence_number'))
         marc, '243..', {'uniform_title': value['a'], 'date_of_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'243__a': 'uniform_title', '243__d': 'date_of_treaty_signing', '243__g': 'miscellaneous_information', '243__f': 'date_of_a_work', '243__h': 'medium', '243__k': 'form_subheading', '243__m': 'medium_of_performance_for_music', '243__l': 'language_of_a_work', '243__o': 'arranged_statement_for_music', '243__n': 'number_of_part_section_of_a_work', '243__p': 'name_of_part_section_of_a_work', '243__s': 'version', '243__r': 'key_for_music', '243__6': 'linkage', '243__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'uniform_title', 'd': 'date_of_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 title_statement:
@@ -956,7 +956,7 @@ title_statement:
                 ('245__8', 'field_link_and_sequence_number'))
         marc, '245..', {'title': value['a'], 'statement_of_responsibility_': value['c'], 'remainder_of_title': value['b'], 'bulk_dates': value['g'], 'inclusive_dates': value['f'], 'medium': value['h'], 'form': value['k'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'245__a': 'title', '245__c': 'statement_of_responsibility_', '245__b': 'remainder_of_title', '245__g': 'bulk_dates', '245__f': 'inclusive_dates', '245__h': 'medium', '245__k': 'form', '245__n': 'number_of_part_section_of_a_work', '245__p': 'name_of_part_section_of_a_work', '245__s': 'version', '245__6': 'linkage', '245__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'title', 'c': 'statement_of_responsibility_', 'b': 'remainder_of_title', 'g': 'bulk_dates', 'f': 'inclusive_dates', 'h': 'medium', 'k': 'form', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', 's': 'version', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 varying_form_of_title:
@@ -975,7 +975,7 @@ varying_form_of_title:
                 ('246__8', 'field_link_and_sequence_number'))
         marc, '246..', {'title_proper_short_title': value['a'], 'remainder_of_title': value['b'], 'miscellaneous_information': value['g'], 'date_or_sequential_designation': value['f'], 'display_text': value['i'], 'medium': value['h'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'246__a': 'title_proper_short_title', '246__b': 'remainder_of_title', '246__g': 'miscellaneous_information', '246__f': 'date_or_sequential_designation', '246__i': 'display_text', '246__h': 'medium', '246__n': 'number_of_part_section_of_a_work', '246__p': 'name_of_part_section_of_a_work', '246__5': 'institution_to_which_field_applies', '246__6': 'linkage', '246__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'title_proper_short_title', 'b': 'remainder_of_title', 'g': 'miscellaneous_information', 'f': 'date_or_sequential_designation', 'i': 'display_text', 'h': 'medium', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 former_title:
@@ -993,7 +993,7 @@ former_title:
                 ('247__8', 'field_link_and_sequence_number'))
         marc, '247..', {'title': value['a'], 'international_standard_serial_number': value['x'], 'remainder_of_title': value['b'], 'miscellaneous_information': value['g'], 'date_or_sequential_designation': value['f'], 'medium': value['h'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'247__a': 'title', '247__x': 'international_standard_serial_number', '247__b': 'remainder_of_title', '247__g': 'miscellaneous_information', '247__f': 'date_or_sequential_designation', '247__h': 'medium', '247__n': 'number_of_part_section_of_a_work', '247__p': 'name_of_part_section_of_a_work', '247__6': 'linkage', '247__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'title', 'x': 'international_standard_serial_number', 'b': 'remainder_of_title', 'g': 'miscellaneous_information', 'f': 'date_or_sequential_designation', 'h': 'medium', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 edition_statement:
@@ -1006,7 +1006,7 @@ edition_statement:
                 ('250__6', 'linkage'))
         marc, '250..', {'edition_statement': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'remainder_of_edition_statement': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'250__a': 'edition_statement', '250__8': 'field_link_and_sequence_number', '250__3': 'materials_specified', '250__b': 'remainder_of_edition_statement', '250__6': 'linkage'}
+        json_for_marc(), {'a': 'edition_statement', '8': 'field_link_and_sequence_number', '3': 'materials_specified', 'b': 'remainder_of_edition_statement', '6': 'linkage'}
 
 @extend
 musical_presentation_statement:
@@ -1017,7 +1017,7 @@ musical_presentation_statement:
                 ('254__6', 'linkage'))
         marc, '254..', {'musical_presentation_statement': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'254__a': 'musical_presentation_statement', '254__8': 'field_link_and_sequence_number', '254__6': 'linkage'}
+        json_for_marc(), {'a': 'musical_presentation_statement', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 cartographic_mathematical_data:
@@ -1034,7 +1034,7 @@ cartographic_mathematical_data:
                 ('255__8', 'field_link_and_sequence_number'))
         marc, '255..', {'statement_of_scale': value['a'], 'statement_of_coordinates': value['c'], 'statement_of_projection': value['b'], 'statement_of_equinox': value['e'], 'statement_of_zone': value['d'], 'exclusion_g_ring_coordinate_pairs': value['g'], 'outer_g_ring_coordinate_pairs': value['f'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'255__a': 'statement_of_scale', '255__c': 'statement_of_coordinates', '255__b': 'statement_of_projection', '255__e': 'statement_of_equinox', '255__d': 'statement_of_zone', '255__g': 'exclusion_g_ring_coordinate_pairs', '255__f': 'outer_g_ring_coordinate_pairs', '255__6': 'linkage', '255__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'statement_of_scale', 'c': 'statement_of_coordinates', 'b': 'statement_of_projection', 'e': 'statement_of_equinox', 'd': 'statement_of_zone', 'g': 'exclusion_g_ring_coordinate_pairs', 'f': 'outer_g_ring_coordinate_pairs', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 computer_file_characteristics:
@@ -1045,7 +1045,7 @@ computer_file_characteristics:
                 ('256__6', 'linkage'))
         marc, '256..', {'computer_file_characteristics': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'256__a': 'computer_file_characteristics', '256__8': 'field_link_and_sequence_number', '256__6': 'linkage'}
+        json_for_marc(), {'a': 'computer_file_characteristics', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 country_of_producing_entity:
@@ -1057,7 +1057,7 @@ country_of_producing_entity:
                 ('257__6', 'linkage'))
         marc, '257..', {'country_of_producing_entity': value['a'], 'field_link_and_sequence_number': value['8'], 'source': value['2'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'257__a': 'country_of_producing_entity', '257__8': 'field_link_and_sequence_number', '257__2': 'source', '257__6': 'linkage'}
+        json_for_marc(), {'a': 'country_of_producing_entity', '8': 'field_link_and_sequence_number', '2': 'source', '6': 'linkage'}
 
 @extend
 philatelic_issue_data:
@@ -1069,7 +1069,7 @@ philatelic_issue_data:
                 ('258__6', 'linkage'))
         marc, '258..', {'issuing_jurisdiction': value['a'], 'field_link_and_sequence_number': value['8'], 'denomination': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'258__a': 'issuing_jurisdiction', '258__8': 'field_link_and_sequence_number', '258__b': 'denomination', '258__6': 'linkage'}
+        json_for_marc(), {'a': 'issuing_jurisdiction', '8': 'field_link_and_sequence_number', 'b': 'denomination', '6': 'linkage'}
 
 @extend
 publication_distribution__imprint:
@@ -1086,7 +1086,7 @@ publication_distribution__imprint:
                 ('260__8', 'field_link_and_sequence_number'))
         marc, '260..', {'place_of_publication_distribution_': value['a'], 'date_of_publication_distribution_': value['c'], 'name_of_publisher_distributor_': value['b'], 'place_of_manufacture': value['e'], 'date_of_manufacture': value['g'], 'manufacturer': value['f'], 'materials_specified': value['3'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'260__a': 'place_of_publication_distribution_', '260__c': 'date_of_publication_distribution_', '260__b': 'name_of_publisher_distributor_', '260__e': 'place_of_manufacture', '260__g': 'date_of_manufacture', '260__f': 'manufacturer', '260__3': 'materials_specified', '260__6': 'linkage', '260__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'place_of_publication_distribution_', 'c': 'date_of_publication_distribution_', 'b': 'name_of_publisher_distributor_', 'e': 'place_of_manufacture', 'g': 'date_of_manufacture', 'f': 'manufacturer', '3': 'materials_specified', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 imprint_statement_for_films_pre_aacr_1_revised:
@@ -1101,7 +1101,7 @@ imprint_statement_for_films_pre_aacr_1_revised:
                 ('261__8', 'field_link_and_sequence_number'))
         marc, '261..', {'producing_company': value['a'], 'releasing_company': value['b'], 'contractual_producer': value['e'], 'date_of_production_release_': value['d'], 'place_of_production_release_': value['f'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'261__a': 'producing_company', '261__b': 'releasing_company', '261__e': 'contractual_producer', '261__d': 'date_of_production_release_', '261__f': 'place_of_production_release_', '261__6': 'linkage', '261__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'producing_company', 'b': 'releasing_company', 'e': 'contractual_producer', 'd': 'date_of_production_release_', 'f': 'place_of_production_release_', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 imprint_statement_for_sound_recordings_pre_aacr_1:
@@ -1116,7 +1116,7 @@ imprint_statement_for_sound_recordings_pre_aacr_1:
                 ('262__8', 'field_link_and_sequence_number'))
         marc, '262..', {'place_of_production_release_': value['a'], 'date_of_production_release_': value['c'], 'publisher_or_trade_name': value['b'], 'serial_identification': value['k'], 'matrix_and_or_take_number': value['l'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'262__a': 'place_of_production_release_', '262__c': 'date_of_production_release_', '262__b': 'publisher_or_trade_name', '262__k': 'serial_identification', '262__l': 'matrix_and_or_take_number', '262__6': 'linkage', '262__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'place_of_production_release_', 'c': 'date_of_production_release_', 'b': 'publisher_or_trade_name', 'k': 'serial_identification', 'l': 'matrix_and_or_take_number', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 projected_publication_date:
@@ -1127,7 +1127,7 @@ projected_publication_date:
                 ('263__6', 'linkage'))
         marc, '263..', {'projected_publication_date': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'263__a': 'projected_publication_date', '263__8': 'field_link_and_sequence_number', '263__6': 'linkage'}
+        json_for_marc(), {'a': 'projected_publication_date', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 production_publication_distribution_manufacture_and_copyright_notice:
@@ -1141,7 +1141,7 @@ production_publication_distribution_manufacture_and_copyright_notice:
                 ('264__8', 'field_link_and_sequence_number'))
         marc, '264..', {'place_of_production_publication_distribution_manufacture': value['a'], 'date_of_production_publication_distribution_manufacture_or_copyright_notice': value['c'], 'name_of_producer_publisher_distributor_manufacturer': value['b'], 'materials_specified': value['3'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'264__a': 'place_of_production_publication_distribution_manufacture', '264__c': 'date_of_production_publication_distribution_manufacture_or_copyright_notice', '264__b': 'name_of_producer_publisher_distributor_manufacturer', '264__3': 'materials_specified', '264__6': 'linkage', '264__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'place_of_production_publication_distribution_manufacture', 'c': 'date_of_production_publication_distribution_manufacture_or_copyright_notice', 'b': 'name_of_producer_publisher_distributor_manufacturer', '3': 'materials_specified', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 address:
@@ -1170,7 +1170,7 @@ address:
                 ('270__z', 'public_note'))
         marc, '270..', {'address': value['a'], 'state_or_province': value['c'], 'city': value['b'], 'postal_code': value['e'], 'country': value['d'], 'attention_name': value['g'], 'terms_preceding_attention_name': value['f'], 'type_of_address': value['i'], 'attention_position': value['h'], 'telephone_number': value['k'], 'specialized_telephone_number': value['j'], 'electronic_mail_address': value['m'], 'fax_number': value['l'], 'tdd_or_tty_number': value['n'], 'title_of_contact_person': value['q'], 'contact_person': value['p'], 'hours': value['r'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'public_note': value['z']}
     producer:
-        json_for_marc(), {'270__a': 'address', '270__c': 'state_or_province', '270__b': 'city', '270__e': 'postal_code', '270__d': 'country', '270__g': 'attention_name', '270__f': 'terms_preceding_attention_name', '270__i': 'type_of_address', '270__h': 'attention_position', '270__k': 'telephone_number', '270__j': 'specialized_telephone_number', '270__m': 'electronic_mail_address', '270__l': 'fax_number', '270__n': 'tdd_or_tty_number', '270__q': 'title_of_contact_person', '270__p': 'contact_person', '270__r': 'hours', '270__4': 'relator_code', '270__6': 'linkage', '270__8': 'field_link_and_sequence_number', '270__z': 'public_note'}
+        json_for_marc(), {'a': 'address', 'c': 'state_or_province', 'b': 'city', 'e': 'postal_code', 'd': 'country', 'g': 'attention_name', 'f': 'terms_preceding_attention_name', 'i': 'type_of_address', 'h': 'attention_position', 'k': 'telephone_number', 'j': 'specialized_telephone_number', 'm': 'electronic_mail_address', 'l': 'fax_number', 'n': 'tdd_or_tty_number', 'q': 'title_of_contact_person', 'p': 'contact_person', 'r': 'hours', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'public_note'}
 
 @extend
 physical_description:
@@ -1187,7 +1187,7 @@ physical_description:
                 ('300__8', 'field_link_and_sequence_number'))
         marc, '300..', {'extent': value['a'], 'dimensions': value['c'], 'other_physical_details': value['b'], 'accompanying_material': value['e'], 'size_of_unit': value['g'], 'type_of_unit': value['f'], 'materials_specified': value['3'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'300__a': 'extent', '300__c': 'dimensions', '300__b': 'other_physical_details', '300__e': 'accompanying_material', '300__g': 'size_of_unit', '300__f': 'type_of_unit', '300__3': 'materials_specified', '300__6': 'linkage', '300__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'extent', 'c': 'dimensions', 'b': 'other_physical_details', 'e': 'accompanying_material', 'g': 'size_of_unit', 'f': 'type_of_unit', '3': 'materials_specified', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 playing_time:
@@ -1198,7 +1198,7 @@ playing_time:
                 ('306__6', 'linkage'))
         marc, '306..', {'playing_time': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'306__a': 'playing_time', '306__8': 'field_link_and_sequence_number', '306__6': 'linkage'}
+        json_for_marc(), {'a': 'playing_time', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 hours_:
@@ -1210,7 +1210,7 @@ hours_:
                 ('307__6', 'linkage'))
         marc, '307..', {'hours': value['a'], 'field_link_and_sequence_number': value['8'], 'additional_information': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'307__a': 'hours', '307__8': 'field_link_and_sequence_number', '307__b': 'additional_information', '307__6': 'linkage'}
+        json_for_marc(), {'a': 'hours', '8': 'field_link_and_sequence_number', 'b': 'additional_information', '6': 'linkage'}
 
 @extend
 current_publication_frequency:
@@ -1222,7 +1222,7 @@ current_publication_frequency:
                 ('310__6', 'linkage'))
         marc, '310..', {'current_publication_frequency': value['a'], 'field_link_and_sequence_number': value['8'], 'date_of_current_publication_frequency': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'310__a': 'current_publication_frequency', '310__8': 'field_link_and_sequence_number', '310__b': 'date_of_current_publication_frequency', '310__6': 'linkage'}
+        json_for_marc(), {'a': 'current_publication_frequency', '8': 'field_link_and_sequence_number', 'b': 'date_of_current_publication_frequency', '6': 'linkage'}
 
 @extend
 former_publication_frequency:
@@ -1234,7 +1234,7 @@ former_publication_frequency:
                 ('321__6', 'linkage'))
         marc, '321..', {'former_publication_frequency': value['a'], 'field_link_and_sequence_number': value['8'], 'dates_of_former_publication_frequency': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'321__a': 'former_publication_frequency', '321__8': 'field_link_and_sequence_number', '321__b': 'dates_of_former_publication_frequency', '321__6': 'linkage'}
+        json_for_marc(), {'a': 'former_publication_frequency', '8': 'field_link_and_sequence_number', 'b': 'dates_of_former_publication_frequency', '6': 'linkage'}
 
 @extend
 content_type:
@@ -1248,7 +1248,7 @@ content_type:
                 ('336__8', 'field_link_and_sequence_number'))
         marc, '336..', {'content_type_term': value['a'], 'content_type_code': value['b'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'336__a': 'content_type_term', '336__b': 'content_type_code', '336__3': 'materials_specified', '336__2': 'source', '336__6': 'linkage', '336__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'content_type_term', 'b': 'content_type_code', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 media_type:
@@ -1262,7 +1262,7 @@ media_type:
                 ('337__8', 'field_link_and_sequence_number'))
         marc, '337..', {'media_type_term': value['a'], 'media_type_code': value['b'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'337__a': 'media_type_term', '337__b': 'media_type_code', '337__3': 'materials_specified', '337__2': 'source', '337__6': 'linkage', '337__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'media_type_term', 'b': 'media_type_code', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 carrier_type:
@@ -1276,7 +1276,7 @@ carrier_type:
                 ('338__8', 'field_link_and_sequence_number'))
         marc, '338..', {'carrier_type_term': value['a'], 'carrier_type_code': value['b'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'338__a': 'carrier_type_term', '338__b': 'carrier_type_code', '338__3': 'materials_specified', '338__2': 'source', '338__6': 'linkage', '338__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'carrier_type_term', 'b': 'carrier_type_code', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 physical_medium:
@@ -1302,7 +1302,7 @@ physical_medium:
                 ('340__8', 'field_link_and_sequence_number'))
         marc, '340..', {'material_base_and_configuration': value['a'], 'materials_applied_to_surface': value['c'], 'dimensions': value['b'], 'support': value['e'], 'information_recording_technique': value['d'], 'production_rate_ratio': value['f'], 'technical_specifications_of_medium': value['i'], 'location_within_medium': value['h'], 'layout': value['k'], 'generation': value['j'], 'book_format': value['m'], 'polarity': value['o'], 'font_size': value['n'], 'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'340__a': 'material_base_and_configuration', '340__c': 'materials_applied_to_surface', '340__b': 'dimensions', '340__e': 'support', '340__d': 'information_recording_technique', '340__f': 'production_rate_ratio', '340__i': 'technical_specifications_of_medium', '340__h': 'location_within_medium', '340__k': 'layout', '340__j': 'generation', '340__m': 'book_format', '340__o': 'polarity', '340__n': 'font_size', '340__0': 'authority_record_control_number_or_standard_number', '340__3': 'materials_specified', '340__2': 'source', '340__6': 'linkage', '340__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'material_base_and_configuration', 'c': 'materials_applied_to_surface', 'b': 'dimensions', 'e': 'support', 'd': 'information_recording_technique', 'f': 'production_rate_ratio', 'i': 'technical_specifications_of_medium', 'h': 'location_within_medium', 'k': 'layout', 'j': 'generation', 'm': 'book_format', 'o': 'polarity', 'n': 'font_size', '0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 geospatial_reference_data:
@@ -1336,7 +1336,7 @@ geospatial_reference_data:
                 ('342__v', 'local_planar_local_or_other_projection_or_grid_description'))
         marc, '342..', {'reference_method_used': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'name': value['a'], 'latitude_resolution': value['c'], 'coordinate_units_or_distance_units': value['b'], 'standard_parallel_or_oblique_line_latitude': value['e'], 'longitude_resolution': value['d'], 'longitude_of_central_meridian_or_projection_center': value['g'], 'oblique_line_longitude': value['f'], 'false_easting': value['i'], 'latitude_of_projection_center_or_projection_origin': value['h'], 'scale_factor': value['k'], 'false_northing': value['j'], 'azimuthal_angle': value['m'], 'height_of_perspective_point_above_surface': value['l'], 'landsat_number_and_path_number': value['o'], 'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole': value['n'], 'ellipsoid_name': value['q'], 'zone_identifier': value['p'], 'denominator_of_flattening_ratio': value['s'], 'semi_major_axis': value['r'], 'vertical_encoding_method': value['u'], 'vertical_resolution': value['t'], 'local_planar_or_local_georeference_information': value['w'], 'local_planar_local_or_other_projection_or_grid_description': value['v']}
     producer:
-        json_for_marc(), {'342__2': 'reference_method_used', '342__6': 'linkage', '342__8': 'field_link_and_sequence_number', '342__a': 'name', '342__c': 'latitude_resolution', '342__b': 'coordinate_units_or_distance_units', '342__e': 'standard_parallel_or_oblique_line_latitude', '342__d': 'longitude_resolution', '342__g': 'longitude_of_central_meridian_or_projection_center', '342__f': 'oblique_line_longitude', '342__i': 'false_easting', '342__h': 'latitude_of_projection_center_or_projection_origin', '342__k': 'scale_factor', '342__j': 'false_northing', '342__m': 'azimuthal_angle', '342__l': 'height_of_perspective_point_above_surface', '342__o': 'landsat_number_and_path_number', '342__n': 'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole', '342__q': 'ellipsoid_name', '342__p': 'zone_identifier', '342__s': 'denominator_of_flattening_ratio', '342__r': 'semi_major_axis', '342__u': 'vertical_encoding_method', '342__t': 'vertical_resolution', '342__w': 'local_planar_or_local_georeference_information', '342__v': 'local_planar_local_or_other_projection_or_grid_description'}
+        json_for_marc(), {'2': 'reference_method_used', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'name', 'c': 'latitude_resolution', 'b': 'coordinate_units_or_distance_units', 'e': 'standard_parallel_or_oblique_line_latitude', 'd': 'longitude_resolution', 'g': 'longitude_of_central_meridian_or_projection_center', 'f': 'oblique_line_longitude', 'i': 'false_easting', 'h': 'latitude_of_projection_center_or_projection_origin', 'k': 'scale_factor', 'j': 'false_northing', 'm': 'azimuthal_angle', 'l': 'height_of_perspective_point_above_surface', 'o': 'landsat_number_and_path_number', 'n': 'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole', 'q': 'ellipsoid_name', 'p': 'zone_identifier', 's': 'denominator_of_flattening_ratio', 'r': 'semi_major_axis', 'u': 'vertical_encoding_method', 't': 'vertical_resolution', 'w': 'local_planar_or_local_georeference_information', 'v': 'local_planar_local_or_other_projection_or_grid_description'}
 
 @extend
 planar_coordinate_data:
@@ -1355,7 +1355,7 @@ planar_coordinate_data:
                 ('343__8', 'field_link_and_sequence_number'))
         marc, '343..', {'planar_coordinate_encoding_method': value['a'], 'abscissa_resolution': value['c'], 'planar_distance_units': value['b'], 'distance_resolution': value['e'], 'ordinate_resolution': value['d'], 'bearing_units': value['g'], 'bearing_resolution': value['f'], 'bearing_reference_meridian': value['i'], 'bearing_reference_direction': value['h'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'343__a': 'planar_coordinate_encoding_method', '343__c': 'abscissa_resolution', '343__b': 'planar_distance_units', '343__e': 'distance_resolution', '343__d': 'ordinate_resolution', '343__g': 'bearing_units', '343__f': 'bearing_resolution', '343__i': 'bearing_reference_meridian', '343__h': 'bearing_reference_direction', '343__6': 'linkage', '343__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'planar_coordinate_encoding_method', 'c': 'abscissa_resolution', 'b': 'planar_distance_units', 'e': 'distance_resolution', 'd': 'ordinate_resolution', 'g': 'bearing_units', 'f': 'bearing_resolution', 'i': 'bearing_reference_meridian', 'h': 'bearing_reference_direction', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 sound_characteristics:
@@ -1376,7 +1376,7 @@ sound_characteristics:
                 ('344__8', 'field_link_and_sequence_number'))
         marc, '344..', {'type_of_recording': value['a'], 'playing_speed': value['c'], 'recording_medium': value['b'], 'track_configuration': value['e'], 'groove_characteristic': value['d'], 'configuration_of_playback_channels': value['g'], 'tape_configuration': value['f'], 'special_playback_characteristics': value['h'], 'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'344__a': 'type_of_recording', '344__c': 'playing_speed', '344__b': 'recording_medium', '344__e': 'track_configuration', '344__d': 'groove_characteristic', '344__g': 'configuration_of_playback_channels', '344__f': 'tape_configuration', '344__h': 'special_playback_characteristics', '344__0': 'authority_record_control_number_or_standard_number', '344__3': 'materials_specified', '344__2': 'source', '344__6': 'linkage', '344__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'type_of_recording', 'c': 'playing_speed', 'b': 'recording_medium', 'e': 'track_configuration', 'd': 'groove_characteristic', 'g': 'configuration_of_playback_channels', 'f': 'tape_configuration', 'h': 'special_playback_characteristics', '0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 projection_characteristics_of_moving_image:
@@ -1391,7 +1391,7 @@ projection_characteristics_of_moving_image:
                 ('345__8', 'field_link_and_sequence_number'))
         marc, '345..', {'presentation_format': value['a'], 'projection_speed': value['b'], 'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'345__a': 'presentation_format', '345__b': 'projection_speed', '345__0': 'authority_record_control_number_or_standard_number', '345__3': 'materials_specified', '345__2': 'source', '345__6': 'linkage', '345__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'presentation_format', 'b': 'projection_speed', '0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 video_characteristics:
@@ -1406,7 +1406,7 @@ video_characteristics:
                 ('346__8', 'field_link_and_sequence_number'))
         marc, '346..', {'video_format': value['a'], 'broadcast_standard': value['b'], 'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'346__a': 'video_format', '346__b': 'broadcast_standard', '346__0': 'authority_record_control_number_or_standard_number', '346__3': 'materials_specified', '346__2': 'source', '346__6': 'linkage', '346__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'video_format', 'b': 'broadcast_standard', '0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 digital_file_characteristics:
@@ -1425,7 +1425,7 @@ digital_file_characteristics:
                 ('347__8', 'field_link_and_sequence_number'))
         marc, '347..', {'file_type': value['a'], 'file_size': value['c'], 'encoding_format': value['b'], 'regional_encoding': value['e'], 'resolution': value['d'], 'transmission_speed': value['f'], 'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'347__a': 'file_type', '347__c': 'file_size', '347__b': 'encoding_format', '347__e': 'regional_encoding', '347__d': 'resolution', '347__f': 'transmission_speed', '347__0': 'authority_record_control_number_or_standard_number', '347__3': 'materials_specified', '347__2': 'source', '347__6': 'linkage', '347__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'file_type', 'c': 'file_size', 'b': 'encoding_format', 'e': 'regional_encoding', 'd': 'resolution', 'f': 'transmission_speed', '0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 organization_and_arrangement_of_materials:
@@ -1439,7 +1439,7 @@ organization_and_arrangement_of_materials:
                 ('351__8', 'field_link_and_sequence_number'))
         marc, '351..', {'organization': value['a'], 'hierarchical_level': value['c'], 'arrangement': value['b'], 'materials_specified': value['3'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'351__a': 'organization', '351__c': 'hierarchical_level', '351__b': 'arrangement', '351__3': 'materials_specified', '351__6': 'linkage', '351__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'organization', 'c': 'hierarchical_level', 'b': 'arrangement', '3': 'materials_specified', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 digital_graphic_representation:
@@ -1458,7 +1458,7 @@ digital_graphic_representation:
                 ('352__8', 'field_link_and_sequence_number'))
         marc, '352..', {'direct_reference_method': value['a'], 'object_count': value['c'], 'object_type': value['b'], 'column_count': value['e'], 'row_count': value['d'], 'vpf_topology_level': value['g'], 'vertical_count': value['f'], 'indirect_reference_description': value['i'], 'format_of_the_digital_image': value['q'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'352__a': 'direct_reference_method', '352__c': 'object_count', '352__b': 'object_type', '352__e': 'column_count', '352__d': 'row_count', '352__g': 'vpf_topology_level', '352__f': 'vertical_count', '352__i': 'indirect_reference_description', '352__q': 'format_of_the_digital_image', '352__6': 'linkage', '352__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'direct_reference_method', 'c': 'object_count', 'b': 'object_type', 'e': 'column_count', 'd': 'row_count', 'g': 'vpf_topology_level', 'f': 'vertical_count', 'i': 'indirect_reference_description', 'q': 'format_of_the_digital_image', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 security_classification_control:
@@ -1477,7 +1477,7 @@ security_classification_control:
                 ('355__8', 'field_link_and_sequence_number'))
         marc, '355..', {'security_classification': value['a'], 'external_dissemination_information': value['c'], 'handling_instructions': value['b'], 'classification_system': value['e'], 'downgrading_or_declassification_event': value['d'], 'downgrading_date': value['g'], 'country_of_origin_code': value['f'], 'declassification_date': value['h'], 'authorization': value['j'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'355__a': 'security_classification', '355__c': 'external_dissemination_information', '355__b': 'handling_instructions', '355__e': 'classification_system', '355__d': 'downgrading_or_declassification_event', '355__g': 'downgrading_date', '355__f': 'country_of_origin_code', '355__h': 'declassification_date', '355__j': 'authorization', '355__6': 'linkage', '355__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'security_classification', 'c': 'external_dissemination_information', 'b': 'handling_instructions', 'e': 'classification_system', 'd': 'downgrading_or_declassification_event', 'g': 'downgrading_date', 'f': 'country_of_origin_code', 'h': 'declassification_date', 'j': 'authorization', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 originator_dissemination_control:
@@ -1491,7 +1491,7 @@ originator_dissemination_control:
                 ('357__8', 'field_link_and_sequence_number'))
         marc, '357..', {'originator_control_term': value['a'], 'authorized_recipients_of_material': value['c'], 'originating_agency': value['b'], 'other_restrictions': value['g'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'357__a': 'originator_control_term', '357__c': 'authorized_recipients_of_material', '357__b': 'originating_agency', '357__g': 'other_restrictions', '357__6': 'linkage', '357__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'originator_control_term', 'c': 'authorized_recipients_of_material', 'b': 'originating_agency', 'g': 'other_restrictions', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 dates_of_publication_and_or_sequential_designation:
@@ -1503,7 +1503,7 @@ dates_of_publication_and_or_sequential_designation:
                 ('362__6', 'linkage'))
         marc, '362..', {'dates_of_publication_and_or_sequential_designation': value['a'], 'field_link_and_sequence_number': value['8'], 'source_of_information': value['z'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'362__a': 'dates_of_publication_and_or_sequential_designation', '362__8': 'field_link_and_sequence_number', '362__z': 'source_of_information', '362__6': 'linkage'}
+        json_for_marc(), {'a': 'dates_of_publication_and_or_sequential_designation', '8': 'field_link_and_sequence_number', 'z': 'source_of_information', '6': 'linkage'}
 
 @extend
 normalized_date_and_sequential_designation:
@@ -1530,7 +1530,7 @@ normalized_date_and_sequential_designation:
                 ('363__v', 'first_level_of_chronology_issuance'))
         marc, '363..', {'first_level_of_enumeration': value['a'], 'nonpublic_note': value['x'], 'third_level_of_enumeration': value['c'], 'second_level_of_enumeration': value['b'], 'fifth_level_of_enumeration': value['e'], 'fourth_level_of_enumeration': value['d'], 'alternative_numbering_scheme_first_level_of_enumeration': value['g'], 'sixth_level_of_enumeration': value['f'], 'first_level_of_chronology': value['i'], 'alternative_numbering_scheme_second_level_of_enumeration': value['h'], 'third_level_of_chronology': value['k'], 'second_level_of_chronology': value['j'], 'alternative_numbering_scheme_chronology': value['m'], 'fourth_level_of_chronology': value['l'], 'first_level_textual_designation': value['u'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'public_note': value['z'], 'first_level_of_chronology_issuance': value['v']}
     producer:
-        json_for_marc(), {'363__a': 'first_level_of_enumeration', '363__x': 'nonpublic_note', '363__c': 'third_level_of_enumeration', '363__b': 'second_level_of_enumeration', '363__e': 'fifth_level_of_enumeration', '363__d': 'fourth_level_of_enumeration', '363__g': 'alternative_numbering_scheme_first_level_of_enumeration', '363__f': 'sixth_level_of_enumeration', '363__i': 'first_level_of_chronology', '363__h': 'alternative_numbering_scheme_second_level_of_enumeration', '363__k': 'third_level_of_chronology', '363__j': 'second_level_of_chronology', '363__m': 'alternative_numbering_scheme_chronology', '363__l': 'fourth_level_of_chronology', '363__u': 'first_level_textual_designation', '363__6': 'linkage', '363__8': 'field_link_and_sequence_number', '363__z': 'public_note', '363__v': 'first_level_of_chronology_issuance'}
+        json_for_marc(), {'a': 'first_level_of_enumeration', 'x': 'nonpublic_note', 'c': 'third_level_of_enumeration', 'b': 'second_level_of_enumeration', 'e': 'fifth_level_of_enumeration', 'd': 'fourth_level_of_enumeration', 'g': 'alternative_numbering_scheme_first_level_of_enumeration', 'f': 'sixth_level_of_enumeration', 'i': 'first_level_of_chronology', 'h': 'alternative_numbering_scheme_second_level_of_enumeration', 'k': 'third_level_of_chronology', 'j': 'second_level_of_chronology', 'm': 'alternative_numbering_scheme_chronology', 'l': 'fourth_level_of_chronology', 'u': 'first_level_textual_designation', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'public_note', 'v': 'first_level_of_chronology_issuance'}
 
 @extend
 trade_price:
@@ -1553,7 +1553,7 @@ trade_price:
                 ('365__8', 'field_link_and_sequence_number'))
         marc, '365..', {'price_type_code': value['a'], 'currency_code': value['c'], 'price_amount': value['b'], 'price_note': value['e'], 'unit_of_pricing': value['d'], 'price_effective_until': value['g'], 'price_effective_from': value['f'], 'tax_rate_2': value['i'], 'tax_rate_1': value['h'], 'marc_country_code': value['k'], 'iso_country_code': value['j'], 'identification_of_pricing_entity': value['m'], 'source_of_price_type_code': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'365__a': 'price_type_code', '365__c': 'currency_code', '365__b': 'price_amount', '365__e': 'price_note', '365__d': 'unit_of_pricing', '365__g': 'price_effective_until', '365__f': 'price_effective_from', '365__i': 'tax_rate_2', '365__h': 'tax_rate_1', '365__k': 'marc_country_code', '365__j': 'iso_country_code', '365__m': 'identification_of_pricing_entity', '365__2': 'source_of_price_type_code', '365__6': 'linkage', '365__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'price_type_code', 'c': 'currency_code', 'b': 'price_amount', 'e': 'price_note', 'd': 'unit_of_pricing', 'g': 'price_effective_until', 'f': 'price_effective_from', 'i': 'tax_rate_2', 'h': 'tax_rate_1', 'k': 'marc_country_code', 'j': 'iso_country_code', 'm': 'identification_of_pricing_entity', '2': 'source_of_price_type_code', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 trade_availability_information:
@@ -1574,7 +1574,7 @@ trade_availability_information:
                 ('366__8', 'field_link_and_sequence_number'))
         marc, '366..', {'publishers_compressed_title_identification': value['a'], 'availability_status_code': value['c'], 'detailed_date_of_publication': value['b'], 'note': value['e'], 'expected_next_availability_date': value['d'], 'date_made_out_of_print': value['g'], 'publisher_s_discount_category': value['f'], 'marc_country_code': value['k'], 'iso_country_code': value['j'], 'identification_of_agency': value['m'], 'source_of_availability_status_code': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'366__a': 'publishers_compressed_title_identification', '366__c': 'availability_status_code', '366__b': 'detailed_date_of_publication', '366__e': 'note', '366__d': 'expected_next_availability_date', '366__g': 'date_made_out_of_print', '366__f': 'publisher_s_discount_category', '366__k': 'marc_country_code', '366__j': 'iso_country_code', '366__m': 'identification_of_agency', '366__2': 'source_of_availability_status_code', '366__6': 'linkage', '366__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'publishers_compressed_title_identification', 'c': 'availability_status_code', 'b': 'detailed_date_of_publication', 'e': 'note', 'd': 'expected_next_availability_date', 'g': 'date_made_out_of_print', 'f': 'publisher_s_discount_category', 'k': 'marc_country_code', 'j': 'iso_country_code', 'm': 'identification_of_agency', '2': 'source_of_availability_status_code', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 associated_language:
@@ -1587,7 +1587,7 @@ associated_language:
                 ('377__6', 'linkage'))
         marc, '377..', {'language_code': value['a'], 'field_link_and_sequence_number': value['8'], 'source': value['2'], 'language_term': value['l'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'377__a': 'language_code', '377__8': 'field_link_and_sequence_number', '377__2': 'source', '377__l': 'language_term', '377__6': 'linkage'}
+        json_for_marc(), {'a': 'language_code', '8': 'field_link_and_sequence_number', '2': 'source', 'l': 'language_term', '6': 'linkage'}
 
 @extend
 form_of_work:
@@ -1600,7 +1600,7 @@ form_of_work:
                 ('380__6', 'linkage'))
         marc, '380..', {'form_of_work': value['a'], 'record_control_number': value['0'], 'source_of_term': value['2'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'380__a': 'form_of_work', '380__0': 'record_control_number', '380__2': 'source_of_term', '380__8': 'field_link_and_sequence_number', '380__6': 'linkage'}
+        json_for_marc(), {'a': 'form_of_work', '0': 'record_control_number', '2': 'source_of_term', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 other_distinguishing_characteristics_of_work_or_expression:
@@ -1615,7 +1615,7 @@ other_distinguishing_characteristics_of_work_or_expression:
                 ('381__8', 'field_link_and_sequence_number'))
         marc, '381..', {'other_distinguishing_characteristic': value['a'], 'source_of_information': value['v'], 'record_control_number': value['0'], 'source_of_term': value['2'], 'uniform_resource_identifier': value['u'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'381__a': 'other_distinguishing_characteristic', '381__v': 'source_of_information', '381__0': 'record_control_number', '381__2': 'source_of_term', '381__u': 'uniform_resource_identifier', '381__6': 'linkage', '381__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'other_distinguishing_characteristic', 'v': 'source_of_information', '0': 'record_control_number', '2': 'source_of_term', 'u': 'uniform_resource_identifier', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 medium_of_performance:
@@ -1634,7 +1634,7 @@ medium_of_performance:
                 ('382__8', 'field_link_and_sequence_number'))
         marc, '382..', {'medium_of_performance': value['a'], 'soloist': value['b'], 'doubling_instrument': value['d'], 'alternative_medium_of_performance': value['p'], 'note': value['v'], 'number_of_performers_of_the_same_medium': value['n'], 'authority_record_control_number_or_standard_number': value['0'], 'total_number_of_performers': value['s'], 'source_of_term': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'382__a': 'medium_of_performance', '382__b': 'soloist', '382__d': 'doubling_instrument', '382__p': 'alternative_medium_of_performance', '382__v': 'note', '382__n': 'number_of_performers_of_the_same_medium', '382__0': 'authority_record_control_number_or_standard_number', '382__s': 'total_number_of_performers', '382__2': 'source_of_term', '382__6': 'linkage', '382__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'medium_of_performance', 'b': 'soloist', 'd': 'doubling_instrument', 'p': 'alternative_medium_of_performance', 'v': 'note', 'n': 'number_of_performers_of_the_same_medium', '0': 'authority_record_control_number_or_standard_number', 's': 'total_number_of_performers', '2': 'source_of_term', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 numeric_designation_of_musical_work:
@@ -1650,7 +1650,7 @@ numeric_designation_of_musical_work:
                 ('383__8', 'field_link_and_sequence_number'))
         marc, '383..', {'serial_number': value['a'], 'thematic_index_number': value['c'], 'opus_number': value['b'], 'publisher_associated_with_opus_number': value['e'], 'thematic_index_code': value['d'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'383__a': 'serial_number', '383__c': 'thematic_index_number', '383__b': 'opus_number', '383__e': 'publisher_associated_with_opus_number', '383__d': 'thematic_index_code', '383__2': 'source', '383__6': 'linkage', '383__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'serial_number', 'c': 'thematic_index_number', 'b': 'opus_number', 'e': 'publisher_associated_with_opus_number', 'd': 'thematic_index_code', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 key:
@@ -1661,7 +1661,7 @@ key:
                 ('384__6', 'linkage'))
         marc, '384..', {'key': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'384__a': 'key', '384__8': 'field_link_and_sequence_number', '384__6': 'linkage'}
+        json_for_marc(), {'a': 'key', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 audience_characteristics:
@@ -1678,7 +1678,7 @@ audience_characteristics:
                 ('385__8', 'field_link_and_sequence_number'))
         marc, '385..', {'audience_term': value['a'], 'audience_code': value['b'], 'demographic_group_term': value['m'], 'demographic_group_code': value['n'], 'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'385__a': 'audience_term', '385__b': 'audience_code', '385__m': 'demographic_group_term', '385__n': 'demographic_group_code', '385__0': 'authority_record_control_number_or_standard_number', '385__3': 'materials_specified', '385__2': 'source', '385__6': 'linkage', '385__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'audience_term', 'b': 'audience_code', 'm': 'demographic_group_term', 'n': 'demographic_group_code', '0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 creator_contributor_characteristics:
@@ -1695,7 +1695,7 @@ creator_contributor_characteristics:
                 ('386__8', 'field_link_and_sequence_number'))
         marc, '386..', {'creator_contributor_term': value['a'], 'creator_contributor_code': value['b'], 'demographic_group_term': value['m'], 'demographic_group_code': value['n'], 'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'386__a': 'creator_contributor_term', '386__b': 'creator_contributor_code', '386__m': 'demographic_group_term', '386__n': 'demographic_group_code', '386__0': 'authority_record_control_number_or_standard_number', '386__3': 'materials_specified', '386__2': 'source', '386__6': 'linkage', '386__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'creator_contributor_term', 'b': 'creator_contributor_code', 'm': 'demographic_group_term', 'n': 'demographic_group_code', '0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 series_statement_added_entry_personal_name:
@@ -1721,7 +1721,7 @@ series_statement_added_entry_personal_name:
                 ('400__t', 'title_of_a_work'))
         marc, '400..', {'personal_name': value['a'], 'international_standard_serial_number': value['x'], 'titles_and_other_words_associated_with_a_name': value['c'], 'numeration': value['b'], 'relator_term': value['e'], 'dates_associated_with_a_name': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'form_subheading': value['k'], 'volume_sequential_designation': value['v'], 'language_of_a_work': value['l'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'affiliation': value['u'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'title_of_a_work': value['t']}
     producer:
-        json_for_marc(), {'400__a': 'personal_name', '400__x': 'international_standard_serial_number', '400__c': 'titles_and_other_words_associated_with_a_name', '400__b': 'numeration', '400__e': 'relator_term', '400__d': 'dates_associated_with_a_name', '400__g': 'miscellaneous_information', '400__f': 'date_of_a_work', '400__k': 'form_subheading', '400__v': 'volume_sequential_designation', '400__l': 'language_of_a_work', '400__n': 'number_of_part_section_of_a_work', '400__p': 'name_of_part_section_of_a_work', '400__u': 'affiliation', '400__4': 'relator_code', '400__6': 'linkage', '400__8': 'field_link_and_sequence_number', '400__t': 'title_of_a_work'}
+        json_for_marc(), {'a': 'personal_name', 'x': 'international_standard_serial_number', 'c': 'titles_and_other_words_associated_with_a_name', 'b': 'numeration', 'e': 'relator_term', 'd': 'dates_associated_with_a_name', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'k': 'form_subheading', 'v': 'volume_sequential_designation', 'l': 'language_of_a_work', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', 'u': 'affiliation', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 't': 'title_of_a_work'}
 
 @extend
 series_statement_added_entry_corporate_name:
@@ -1747,7 +1747,7 @@ series_statement_added_entry_corporate_name:
                 ('410__t', 'title_of_a_work'))
         marc, '410..', {'corporate_name_or_jurisdiction_name_as_entry_element': value['a'], 'international_standard_serial_number': value['x'], 'location_of_meeting': value['c'], 'subordinate_unit': value['b'], 'relator_term': value['e'], 'date_of_meeting_or_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'form_subheading': value['k'], 'volume_sequential_designation': value['v'], 'language_of_a_work': value['l'], 'number_of_part_section_meeting': value['n'], 'name_of_part_section_of_a_work': value['p'], 'affiliation': value['u'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'title_of_a_work': value['t']}
     producer:
-        json_for_marc(), {'410__a': 'corporate_name_or_jurisdiction_name_as_entry_element', '410__x': 'international_standard_serial_number', '410__c': 'location_of_meeting', '410__b': 'subordinate_unit', '410__e': 'relator_term', '410__d': 'date_of_meeting_or_treaty_signing', '410__g': 'miscellaneous_information', '410__f': 'date_of_a_work', '410__k': 'form_subheading', '410__v': 'volume_sequential_designation', '410__l': 'language_of_a_work', '410__n': 'number_of_part_section_meeting', '410__p': 'name_of_part_section_of_a_work', '410__u': 'affiliation', '410__4': 'relator_code', '410__6': 'linkage', '410__8': 'field_link_and_sequence_number', '410__t': 'title_of_a_work'}
+        json_for_marc(), {'a': 'corporate_name_or_jurisdiction_name_as_entry_element', 'x': 'international_standard_serial_number', 'c': 'location_of_meeting', 'b': 'subordinate_unit', 'e': 'relator_term', 'd': 'date_of_meeting_or_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'k': 'form_subheading', 'v': 'volume_sequential_designation', 'l': 'language_of_a_work', 'n': 'number_of_part_section_meeting', 'p': 'name_of_part_section_of_a_work', 'u': 'affiliation', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 't': 'title_of_a_work'}
 
 @extend
 series_statement_added_entry_meeting_name:
@@ -1773,7 +1773,7 @@ series_statement_added_entry_meeting_name:
                 ('411__t', 'title_of_a_work'))
         marc, '411..', {'meeting_name_or_jurisdiction_name_as_entry_element': value['a'], 'international_standard_serial_number': value['x'], 'location_of_meeting': value['c'], 'subordinate_unit': value['e'], 'date_of_meeting': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'form_subheading': value['k'], 'volume_sequential_designation': value['v'], 'language_of_a_work': value['l'], 'number_of_part_section_meeting': value['n'], 'name_of_meeting_following_jurisdiction_name_entry_element': value['q'], 'name_of_part_section_of_a_work': value['p'], 'affiliation': value['u'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'title_of_a_work': value['t']}
     producer:
-        json_for_marc(), {'411__a': 'meeting_name_or_jurisdiction_name_as_entry_element', '411__x': 'international_standard_serial_number', '411__c': 'location_of_meeting', '411__e': 'subordinate_unit', '411__d': 'date_of_meeting', '411__g': 'miscellaneous_information', '411__f': 'date_of_a_work', '411__k': 'form_subheading', '411__v': 'volume_sequential_designation', '411__l': 'language_of_a_work', '411__n': 'number_of_part_section_meeting', '411__q': 'name_of_meeting_following_jurisdiction_name_entry_element', '411__p': 'name_of_part_section_of_a_work', '411__u': 'affiliation', '411__4': 'relator_code', '411__6': 'linkage', '411__8': 'field_link_and_sequence_number', '411__t': 'title_of_a_work'}
+        json_for_marc(), {'a': 'meeting_name_or_jurisdiction_name_as_entry_element', 'x': 'international_standard_serial_number', 'c': 'location_of_meeting', 'e': 'subordinate_unit', 'd': 'date_of_meeting', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'k': 'form_subheading', 'v': 'volume_sequential_designation', 'l': 'language_of_a_work', 'n': 'number_of_part_section_meeting', 'q': 'name_of_meeting_following_jurisdiction_name_entry_element', 'p': 'name_of_part_section_of_a_work', 'u': 'affiliation', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 't': 'title_of_a_work'}
 
 @extend
 series_statement_added_entry_title:
@@ -1790,7 +1790,7 @@ series_statement_added_entry_title:
                 ('440__8', 'field_link_and_sequence_number'))
         marc, '440..', {'title': value['a'], 'international_standard_serial_number': value['x'], 'name_of_part_section_of_a_work': value['p'], 'volume_sequential_designation': value['v'], 'number_of_part_section_of_a_work': value['n'], 'authority_record_control_number': value['0'], 'bibliographic_record_control_number': value['w'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'440__a': 'title', '440__x': 'international_standard_serial_number', '440__p': 'name_of_part_section_of_a_work', '440__v': 'volume_sequential_designation', '440__n': 'number_of_part_section_of_a_work', '440__0': 'authority_record_control_number', '440__w': 'bibliographic_record_control_number', '440__6': 'linkage', '440__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'title', 'x': 'international_standard_serial_number', 'p': 'name_of_part_section_of_a_work', 'v': 'volume_sequential_designation', 'n': 'number_of_part_section_of_a_work', '0': 'authority_record_control_number', 'w': 'bibliographic_record_control_number', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 series_statement:
@@ -1805,7 +1805,7 @@ series_statement:
                 ('490__8', 'field_link_and_sequence_number'))
         marc, '490..', {'series_statement': value['a'], 'international_standard_serial_number': value['x'], 'linkage': value['6'], 'library_of_congress_call_number': value['l'], 'materials_specified': value['3'], 'volume_sequential_designation': value['v'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'490__a': 'series_statement', '490__x': 'international_standard_serial_number', '490__6': 'linkage', '490__l': 'library_of_congress_call_number', '490__3': 'materials_specified', '490__v': 'volume_sequential_designation', '490__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'series_statement', 'x': 'international_standard_serial_number', '6': 'linkage', 'l': 'library_of_congress_call_number', '3': 'materials_specified', 'v': 'volume_sequential_designation', '8': 'field_link_and_sequence_number'}
 
 @extend
 general_note:
@@ -1818,7 +1818,7 @@ general_note:
                 ('500__6', 'linkage'))
         marc, '500..', {'general_note': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'500__a': 'general_note', '500__8': 'field_link_and_sequence_number', '500__3': 'materials_specified', '500__5': 'institution_to_which_field_applies', '500__6': 'linkage'}
+        json_for_marc(), {'a': 'general_note', '8': 'field_link_and_sequence_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage'}
 
 @extend
 with_note:
@@ -1830,7 +1830,7 @@ with_note:
                 ('501__6', 'linkage'))
         marc, '501..', {'with_note': value['a'], 'field_link_and_sequence_number': value['8'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'501__a': 'with_note', '501__8': 'field_link_and_sequence_number', '501__5': 'institution_to_which_field_applies', '501__6': 'linkage'}
+        json_for_marc(), {'a': 'with_note', '8': 'field_link_and_sequence_number', '5': 'institution_to_which_field_applies', '6': 'linkage'}
 
 @extend
 dissertation_note:
@@ -1846,7 +1846,7 @@ dissertation_note:
                 ('502__8', 'field_link_and_sequence_number'))
         marc, '502..', {'dissertation_note': value['a'], 'name_of_granting_institution': value['c'], 'degree_type': value['b'], 'year_degree_granted': value['d'], 'miscellaneous_information': value['g'], 'dissertation_identifier': value['o'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'502__a': 'dissertation_note', '502__c': 'name_of_granting_institution', '502__b': 'degree_type', '502__d': 'year_degree_granted', '502__g': 'miscellaneous_information', '502__o': 'dissertation_identifier', '502__6': 'linkage', '502__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'dissertation_note', 'c': 'name_of_granting_institution', 'b': 'degree_type', 'd': 'year_degree_granted', 'g': 'miscellaneous_information', 'o': 'dissertation_identifier', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 bibliography__note:
@@ -1858,7 +1858,7 @@ bibliography__note:
                 ('504__6', 'linkage'))
         marc, '504..', {'bibliography__note': value['a'], 'field_link_and_sequence_number': value['8'], 'number_of_references': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'504__a': 'bibliography__note', '504__8': 'field_link_and_sequence_number', '504__b': 'number_of_references', '504__6': 'linkage'}
+        json_for_marc(), {'a': 'bibliography__note', '8': 'field_link_and_sequence_number', 'b': 'number_of_references', '6': 'linkage'}
 
 @extend
 formatted_contents_note:
@@ -1873,7 +1873,7 @@ formatted_contents_note:
                 ('505__8', 'field_link_and_sequence_number'))
         marc, '505..', {'formatted_contents_note': value['a'], 'miscellaneous_information': value['g'], 'statement_of_responsibility': value['r'], 'uniform_resource_identifier': value['u'], 'title': value['t'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'505__a': 'formatted_contents_note', '505__g': 'miscellaneous_information', '505__r': 'statement_of_responsibility', '505__u': 'uniform_resource_identifier', '505__t': 'title', '505__6': 'linkage', '505__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'formatted_contents_note', 'g': 'miscellaneous_information', 'r': 'statement_of_responsibility', 'u': 'uniform_resource_identifier', 't': 'title', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 restrictions_on_access_note:
@@ -1893,7 +1893,7 @@ restrictions_on_access_note:
                 ('506__u', 'uniform_resource_identifier'))
         marc, '506..', {'terms_governing_access': value['a'], 'physical_access_provisions': value['c'], 'jurisdiction': value['b'], 'authorization': value['e'], 'authorized_users': value['d'], 'standardized_terminology_for_access_restriction': value['f'], 'materials_specified': value['3'], 'source_of_term': value['2'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'uniform_resource_identifier': value['u']}
     producer:
-        json_for_marc(), {'506__a': 'terms_governing_access', '506__c': 'physical_access_provisions', '506__b': 'jurisdiction', '506__e': 'authorization', '506__d': 'authorized_users', '506__f': 'standardized_terminology_for_access_restriction', '506__3': 'materials_specified', '506__2': 'source_of_term', '506__5': 'institution_to_which_field_applies', '506__6': 'linkage', '506__8': 'field_link_and_sequence_number', '506__u': 'uniform_resource_identifier'}
+        json_for_marc(), {'a': 'terms_governing_access', 'c': 'physical_access_provisions', 'b': 'jurisdiction', 'e': 'authorization', 'd': 'authorized_users', 'f': 'standardized_terminology_for_access_restriction', '3': 'materials_specified', '2': 'source_of_term', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number', 'u': 'uniform_resource_identifier'}
 
 @extend
 scale_note_for_graphic_material:
@@ -1905,7 +1905,7 @@ scale_note_for_graphic_material:
                 ('507__6', 'linkage'))
         marc, '507..', {'representative_fraction_of_scale_note': value['a'], 'field_link_and_sequence_number': value['8'], 'remainder_of_scale_note': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'507__a': 'representative_fraction_of_scale_note', '507__8': 'field_link_and_sequence_number', '507__b': 'remainder_of_scale_note', '507__6': 'linkage'}
+        json_for_marc(), {'a': 'representative_fraction_of_scale_note', '8': 'field_link_and_sequence_number', 'b': 'remainder_of_scale_note', '6': 'linkage'}
 
 @extend
 creation_production_credits_note:
@@ -1916,7 +1916,7 @@ creation_production_credits_note:
                 ('508__6', 'linkage'))
         marc, '508..', {'creation_production_credits_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'508__a': 'creation_production_credits_note', '508__8': 'field_link_and_sequence_number', '508__6': 'linkage'}
+        json_for_marc(), {'a': 'creation_production_credits_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 citation_references_note:
@@ -1932,7 +1932,7 @@ citation_references_note:
                 ('510__8', 'field_link_and_sequence_number'))
         marc, '510..', {'name_of_source': value['a'], 'international_standard_serial_number': value['x'], 'location_within_source': value['c'], 'coverage_of_source': value['b'], 'materials_specified': value['3'], 'uniform_resource_identifier': value['u'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'510__a': 'name_of_source', '510__x': 'international_standard_serial_number', '510__c': 'location_within_source', '510__b': 'coverage_of_source', '510__3': 'materials_specified', '510__u': 'uniform_resource_identifier', '510__6': 'linkage', '510__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'name_of_source', 'x': 'international_standard_serial_number', 'c': 'location_within_source', 'b': 'coverage_of_source', '3': 'materials_specified', 'u': 'uniform_resource_identifier', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 participant_or_performer_note:
@@ -1943,7 +1943,7 @@ participant_or_performer_note:
                 ('511__6', 'linkage'))
         marc, '511..', {'participant_or_performer_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'511__a': 'participant_or_performer_note', '511__8': 'field_link_and_sequence_number', '511__6': 'linkage'}
+        json_for_marc(), {'a': 'participant_or_performer_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 type_of_report_and_period_covered_note:
@@ -1955,7 +1955,7 @@ type_of_report_and_period_covered_note:
                 ('513__6', 'linkage'))
         marc, '513..', {'type_of_report': value['a'], 'field_link_and_sequence_number': value['8'], 'period_covered': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'513__a': 'type_of_report', '513__8': 'field_link_and_sequence_number', '513__b': 'period_covered', '513__6': 'linkage'}
+        json_for_marc(), {'a': 'type_of_report', '8': 'field_link_and_sequence_number', 'b': 'period_covered', '6': 'linkage'}
 
 @extend
 data_quality_note:
@@ -1979,7 +1979,7 @@ data_quality_note:
                 ('514__z', 'display_note'))
         marc, '514..', {'attribute_accuracy_report': value['a'], 'attribute_accuracy_explanation': value['c'], 'attribute_accuracy_value': value['b'], 'completeness_report': value['e'], 'logical_consistency_report': value['d'], 'horizontal_position_accuracy_value': value['g'], 'horizontal_position_accuracy_report': value['f'], 'vertical_positional_accuracy_report': value['i'], 'horizontal_position_accuracy_explanation': value['h'], 'vertical_positional_accuracy_explanation': value['k'], 'vertical_positional_accuracy_value': value['j'], 'cloud_cover': value['m'], 'uniform_resource_identifier': value['u'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'display_note': value['z']}
     producer:
-        json_for_marc(), {'514__a': 'attribute_accuracy_report', '514__c': 'attribute_accuracy_explanation', '514__b': 'attribute_accuracy_value', '514__e': 'completeness_report', '514__d': 'logical_consistency_report', '514__g': 'horizontal_position_accuracy_value', '514__f': 'horizontal_position_accuracy_report', '514__i': 'vertical_positional_accuracy_report', '514__h': 'horizontal_position_accuracy_explanation', '514__k': 'vertical_positional_accuracy_explanation', '514__j': 'vertical_positional_accuracy_value', '514__m': 'cloud_cover', '514__u': 'uniform_resource_identifier', '514__6': 'linkage', '514__8': 'field_link_and_sequence_number', '514__z': 'display_note'}
+        json_for_marc(), {'a': 'attribute_accuracy_report', 'c': 'attribute_accuracy_explanation', 'b': 'attribute_accuracy_value', 'e': 'completeness_report', 'd': 'logical_consistency_report', 'g': 'horizontal_position_accuracy_value', 'f': 'horizontal_position_accuracy_report', 'i': 'vertical_positional_accuracy_report', 'h': 'horizontal_position_accuracy_explanation', 'k': 'vertical_positional_accuracy_explanation', 'j': 'vertical_positional_accuracy_value', 'm': 'cloud_cover', 'u': 'uniform_resource_identifier', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'display_note'}
 
 @extend
 numbering_peculiarities_note:
@@ -1990,7 +1990,7 @@ numbering_peculiarities_note:
                 ('515__6', 'linkage'))
         marc, '515..', {'numbering_peculiarities_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'515__a': 'numbering_peculiarities_note', '515__8': 'field_link_and_sequence_number', '515__6': 'linkage'}
+        json_for_marc(), {'a': 'numbering_peculiarities_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 type_of_computer_file_or_data_note:
@@ -2001,7 +2001,7 @@ type_of_computer_file_or_data_note:
                 ('516__6', 'linkage'))
         marc, '516..', {'type_of_computer_file_or_data_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'516__a': 'type_of_computer_file_or_data_note', '516__8': 'field_link_and_sequence_number', '516__6': 'linkage'}
+        json_for_marc(), {'a': 'type_of_computer_file_or_data_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 date_time_and_place_of_an_event_note:
@@ -2018,7 +2018,7 @@ date_time_and_place_of_an_event_note:
                 ('518__8', 'field_link_and_sequence_number'))
         marc, '518..', {'date_time_and_place_of_an_event_note': value['a'], 'date_of_event': value['d'], 'place_of_event': value['p'], 'other_event_information': value['o'], 'record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_term': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'518__a': 'date_time_and_place_of_an_event_note', '518__d': 'date_of_event', '518__p': 'place_of_event', '518__o': 'other_event_information', '518__0': 'record_control_number', '518__3': 'materials_specified', '518__2': 'source_of_term', '518__6': 'linkage', '518__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'date_time_and_place_of_an_event_note', 'd': 'date_of_event', 'p': 'place_of_event', 'o': 'other_event_information', '0': 'record_control_number', '3': 'materials_specified', '2': 'source_of_term', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 summary_:
@@ -2034,7 +2034,7 @@ summary_:
                 ('520__8', 'field_link_and_sequence_number'))
         marc, '520..', {'summary_': value['a'], 'assigning_source': value['c'], 'expansion_of_summary_note': value['b'], 'materials_specified': value['3'], 'source': value['2'], 'uniform_resource_identifier': value['u'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'520__a': 'summary_', '520__c': 'assigning_source', '520__b': 'expansion_of_summary_note', '520__3': 'materials_specified', '520__2': 'source', '520__u': 'uniform_resource_identifier', '520__6': 'linkage', '520__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'summary_', 'c': 'assigning_source', 'b': 'expansion_of_summary_note', '3': 'materials_specified', '2': 'source', 'u': 'uniform_resource_identifier', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 target_audience_note:
@@ -2047,7 +2047,7 @@ target_audience_note:
                 ('521__6', 'linkage'))
         marc, '521..', {'target_audience_note': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'source': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'521__a': 'target_audience_note', '521__8': 'field_link_and_sequence_number', '521__3': 'materials_specified', '521__b': 'source', '521__6': 'linkage'}
+        json_for_marc(), {'a': 'target_audience_note', '8': 'field_link_and_sequence_number', '3': 'materials_specified', 'b': 'source', '6': 'linkage'}
 
 @extend
 geographic_coverage_note:
@@ -2058,7 +2058,7 @@ geographic_coverage_note:
                 ('522__6', 'linkage'))
         marc, '522..', {'geographic_coverage_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'522__a': 'geographic_coverage_note', '522__8': 'field_link_and_sequence_number', '522__6': 'linkage'}
+        json_for_marc(), {'a': 'geographic_coverage_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 preferred_citation_of_described_materials_note:
@@ -2071,7 +2071,7 @@ preferred_citation_of_described_materials_note:
                 ('524__6', 'linkage'))
         marc, '524..', {'preferred_citation_of_described_materials_note': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'source_of_schema_used': value['2'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'524__a': 'preferred_citation_of_described_materials_note', '524__8': 'field_link_and_sequence_number', '524__3': 'materials_specified', '524__2': 'source_of_schema_used', '524__6': 'linkage'}
+        json_for_marc(), {'a': 'preferred_citation_of_described_materials_note', '8': 'field_link_and_sequence_number', '3': 'materials_specified', '2': 'source_of_schema_used', '6': 'linkage'}
 
 @extend
 supplement_note:
@@ -2082,7 +2082,7 @@ supplement_note:
                 ('525__6', 'linkage'))
         marc, '525..', {'supplement_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'525__a': 'supplement_note', '525__8': 'field_link_and_sequence_number', '525__6': 'linkage'}
+        json_for_marc(), {'a': 'supplement_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 study_program_information_note:
@@ -2100,7 +2100,7 @@ study_program_information_note:
                 ('526__z', 'public_note'))
         marc, '526..', {'program_name': value['a'], 'nonpublic_note': value['x'], 'reading_level': value['c'], 'interest_level': value['b'], 'title_point_value': value['d'], 'display_text': value['i'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'public_note': value['z']}
     producer:
-        json_for_marc(), {'526__a': 'program_name', '526__x': 'nonpublic_note', '526__c': 'reading_level', '526__b': 'interest_level', '526__d': 'title_point_value', '526__i': 'display_text', '526__5': 'institution_to_which_field_applies', '526__6': 'linkage', '526__8': 'field_link_and_sequence_number', '526__z': 'public_note'}
+        json_for_marc(), {'a': 'program_name', 'x': 'nonpublic_note', 'c': 'reading_level', 'b': 'interest_level', 'd': 'title_point_value', 'i': 'display_text', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'public_note'}
 
 @extend
 additional_physical_form_available_note:
@@ -2116,7 +2116,7 @@ additional_physical_form_available_note:
                 ('530__8', 'field_link_and_sequence_number'))
         marc, '530..', {'additional_physical_form_available_note': value['a'], 'availability_conditions': value['c'], 'availability_source': value['b'], 'order_number': value['d'], 'materials_specified': value['3'], 'uniform_resource_identifier': value['u'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'530__a': 'additional_physical_form_available_note', '530__c': 'availability_conditions', '530__b': 'availability_source', '530__d': 'order_number', '530__3': 'materials_specified', '530__u': 'uniform_resource_identifier', '530__6': 'linkage', '530__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'additional_physical_form_available_note', 'c': 'availability_conditions', 'b': 'availability_source', 'd': 'order_number', '3': 'materials_specified', 'u': 'uniform_resource_identifier', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 reproduction_note:
@@ -2137,7 +2137,7 @@ reproduction_note:
                 ('533__8', 'field_link_and_sequence_number'))
         marc, '533..', {'type_of_reproduction': value['a'], 'agency_responsible_for_reproduction': value['c'], 'place_of_reproduction': value['b'], 'physical_description_of_reproduction': value['e'], 'date_of_reproduction': value['d'], 'series_statement_of_reproduction': value['f'], 'dates_and_or_sequential_designation_of_issues_reproduced': value['m'], 'note_about_reproduction': value['n'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'fixed_length_data_elements_of_reproduction': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'533__a': 'type_of_reproduction', '533__c': 'agency_responsible_for_reproduction', '533__b': 'place_of_reproduction', '533__e': 'physical_description_of_reproduction', '533__d': 'date_of_reproduction', '533__f': 'series_statement_of_reproduction', '533__m': 'dates_and_or_sequential_designation_of_issues_reproduced', '533__n': 'note_about_reproduction', '533__3': 'materials_specified', '533__5': 'institution_to_which_field_applies', '533__7': 'fixed_length_data_elements_of_reproduction', '533__6': 'linkage', '533__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'type_of_reproduction', 'c': 'agency_responsible_for_reproduction', 'b': 'place_of_reproduction', 'e': 'physical_description_of_reproduction', 'd': 'date_of_reproduction', 'f': 'series_statement_of_reproduction', 'm': 'dates_and_or_sequential_designation_of_issues_reproduced', 'n': 'note_about_reproduction', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '7': 'fixed_length_data_elements_of_reproduction', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 original_version_note:
@@ -2162,7 +2162,7 @@ original_version_note:
                 ('534__z', 'international_standard_book_number'))
         marc, '534..', {'main_entry_of_original': value['a'], 'international_standard_serial_number': value['x'], 'publication_distribution__of_original': value['c'], 'edition_statement_of_original': value['b'], 'physical_description__of_original': value['e'], 'series_statement_of_original': value['f'], 'key_title_of_original': value['k'], 'material_specific_details': value['m'], 'location_of_original': value['l'], 'other_resource_identifier': value['o'], 'note_about_original': value['n'], 'introductory_phrase': value['p'], 'materials_specified': value['3'], 'title_statement_of_original': value['t'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'534__a': 'main_entry_of_original', '534__x': 'international_standard_serial_number', '534__c': 'publication_distribution__of_original', '534__b': 'edition_statement_of_original', '534__e': 'physical_description__of_original', '534__f': 'series_statement_of_original', '534__k': 'key_title_of_original', '534__m': 'material_specific_details', '534__l': 'location_of_original', '534__o': 'other_resource_identifier', '534__n': 'note_about_original', '534__p': 'introductory_phrase', '534__3': 'materials_specified', '534__t': 'title_statement_of_original', '534__6': 'linkage', '534__8': 'field_link_and_sequence_number', '534__z': 'international_standard_book_number'}
+        json_for_marc(), {'a': 'main_entry_of_original', 'x': 'international_standard_serial_number', 'c': 'publication_distribution__of_original', 'b': 'edition_statement_of_original', 'e': 'physical_description__of_original', 'f': 'series_statement_of_original', 'k': 'key_title_of_original', 'm': 'material_specific_details', 'l': 'location_of_original', 'o': 'other_resource_identifier', 'n': 'note_about_original', 'p': 'introductory_phrase', '3': 'materials_specified', 't': 'title_statement_of_original', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'international_standard_book_number'}
 
 @extend
 location_of_originals_duplicates_note:
@@ -2178,7 +2178,7 @@ location_of_originals_duplicates_note:
                 ('535__8', 'field_link_and_sequence_number'))
         marc, '535..', {'custodian': value['a'], 'country': value['c'], 'postal_address': value['b'], 'telecommunications_address': value['d'], 'repository_location_code': value['g'], 'materials_specified': value['3'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'535__a': 'custodian', '535__c': 'country', '535__b': 'postal_address', '535__d': 'telecommunications_address', '535__g': 'repository_location_code', '535__3': 'materials_specified', '535__6': 'linkage', '535__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'custodian', 'c': 'country', 'b': 'postal_address', 'd': 'telecommunications_address', 'g': 'repository_location_code', '3': 'materials_specified', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 funding_information_note:
@@ -2196,7 +2196,7 @@ funding_information_note:
                 ('536__8', 'field_link_and_sequence_number'))
         marc, '536..', {'text_of_note': value['a'], 'grant_number': value['c'], 'contract_number': value['b'], 'program_element_number': value['e'], 'undifferentiated_number': value['d'], 'task_number': value['g'], 'project_number': value['f'], 'work_unit_number': value['h'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'536__a': 'text_of_note', '536__c': 'grant_number', '536__b': 'contract_number', '536__e': 'program_element_number', '536__d': 'undifferentiated_number', '536__g': 'task_number', '536__f': 'project_number', '536__h': 'work_unit_number', '536__6': 'linkage', '536__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'text_of_note', 'c': 'grant_number', 'b': 'contract_number', 'e': 'program_element_number', 'd': 'undifferentiated_number', 'g': 'task_number', 'f': 'project_number', 'h': 'work_unit_number', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 system_details_note:
@@ -2211,7 +2211,7 @@ system_details_note:
                 ('538__u', 'uniform_resource_identifier'))
         marc, '538..', {'system_details_note': value['a'], 'display_text': value['i'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'uniform_resource_identifier': value['u']}
     producer:
-        json_for_marc(), {'538__a': 'system_details_note', '538__i': 'display_text', '538__3': 'materials_specified', '538__5': 'institution_to_which_field_applies', '538__6': 'linkage', '538__8': 'field_link_and_sequence_number', '538__u': 'uniform_resource_identifier'}
+        json_for_marc(), {'a': 'system_details_note', 'i': 'display_text', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number', 'u': 'uniform_resource_identifier'}
 
 @extend
 terms_governing_use_and_reproduction_note:
@@ -2228,7 +2228,7 @@ terms_governing_use_and_reproduction_note:
                 ('540__u', 'uniform_resource_identifier'))
         marc, '540..', {'terms_governing_use_and_reproduction': value['a'], 'authorization': value['c'], 'jurisdiction': value['b'], 'authorized_users': value['d'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'uniform_resource_identifier': value['u']}
     producer:
-        json_for_marc(), {'540__a': 'terms_governing_use_and_reproduction', '540__c': 'authorization', '540__b': 'jurisdiction', '540__d': 'authorized_users', '540__3': 'materials_specified', '540__5': 'institution_to_which_field_applies', '540__6': 'linkage', '540__8': 'field_link_and_sequence_number', '540__u': 'uniform_resource_identifier'}
+        json_for_marc(), {'a': 'terms_governing_use_and_reproduction', 'c': 'authorization', 'b': 'jurisdiction', 'd': 'authorized_users', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number', 'u': 'uniform_resource_identifier'}
 
 @extend
 immediate_source_of_acquisition_note:
@@ -2249,7 +2249,7 @@ immediate_source_of_acquisition_note:
                 ('541__8', 'field_link_and_sequence_number'))
         marc, '541..', {'source_of_acquisition': value['a'], 'method_of_acquisition': value['c'], 'address': value['b'], 'accession_number': value['e'], 'date_of_acquisition': value['d'], 'owner': value['f'], 'purchase_price': value['h'], 'type_of_unit': value['o'], 'extent': value['n'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'541__a': 'source_of_acquisition', '541__c': 'method_of_acquisition', '541__b': 'address', '541__e': 'accession_number', '541__d': 'date_of_acquisition', '541__f': 'owner', '541__h': 'purchase_price', '541__o': 'type_of_unit', '541__n': 'extent', '541__3': 'materials_specified', '541__5': 'institution_to_which_field_applies', '541__6': 'linkage', '541__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'source_of_acquisition', 'c': 'method_of_acquisition', 'b': 'address', 'e': 'accession_number', 'd': 'date_of_acquisition', 'f': 'owner', 'h': 'purchase_price', 'o': 'type_of_unit', 'n': 'extent', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 information_relating_to_copyright_status:
@@ -2280,7 +2280,7 @@ information_relating_to_copyright_status:
                 ('542__u', 'uniform_resource_identifier'))
         marc, '542..', {'materials_specified': value['3'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'personal_creator': value['a'], 'corporate_creator': value['c'], 'personal_creator_death_date': value['b'], 'copyright_holder_contact_information': value['e'], 'copyright_holder': value['d'], 'copyright_date': value['g'], 'copyright_statement': value['f'], 'publication_date': value['i'], 'copyright_renewal_date': value['h'], 'publisher': value['k'], 'creation_date': value['j'], 'publication_status': value['m'], 'copyright_status': value['l'], 'research_date': value['o'], 'note': value['n'], 'supplying_agency': value['q'], 'country_of_publication_or_creation': value['p'], 'source_of_information': value['s'], 'jurisdiction_of_copyright_assessment': value['r'], 'uniform_resource_identifier': value['u']}
     producer:
-        json_for_marc(), {'542__3': 'materials_specified', '542__6': 'linkage', '542__8': 'field_link_and_sequence_number', '542__a': 'personal_creator', '542__c': 'corporate_creator', '542__b': 'personal_creator_death_date', '542__e': 'copyright_holder_contact_information', '542__d': 'copyright_holder', '542__g': 'copyright_date', '542__f': 'copyright_statement', '542__i': 'publication_date', '542__h': 'copyright_renewal_date', '542__k': 'publisher', '542__j': 'creation_date', '542__m': 'publication_status', '542__l': 'copyright_status', '542__o': 'research_date', '542__n': 'note', '542__q': 'supplying_agency', '542__p': 'country_of_publication_or_creation', '542__s': 'source_of_information', '542__r': 'jurisdiction_of_copyright_assessment', '542__u': 'uniform_resource_identifier'}
+        json_for_marc(), {'3': 'materials_specified', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'personal_creator', 'c': 'corporate_creator', 'b': 'personal_creator_death_date', 'e': 'copyright_holder_contact_information', 'd': 'copyright_holder', 'g': 'copyright_date', 'f': 'copyright_statement', 'i': 'publication_date', 'h': 'copyright_renewal_date', 'k': 'publisher', 'j': 'creation_date', 'm': 'publication_status', 'l': 'copyright_status', 'o': 'research_date', 'n': 'note', 'q': 'supplying_agency', 'p': 'country_of_publication_or_creation', 's': 'source_of_information', 'r': 'jurisdiction_of_copyright_assessment', 'u': 'uniform_resource_identifier'}
 
 @extend
 location_of_other_archival_materials_note:
@@ -2297,7 +2297,7 @@ location_of_other_archival_materials_note:
                 ('544__8', 'field_link_and_sequence_number'))
         marc, '544..', {'custodian': value['a'], 'country': value['c'], 'address': value['b'], 'provenance': value['e'], 'title': value['d'], 'note': value['n'], 'materials_specified': value['3'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'544__a': 'custodian', '544__c': 'country', '544__b': 'address', '544__e': 'provenance', '544__d': 'title', '544__n': 'note', '544__3': 'materials_specified', '544__6': 'linkage', '544__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'custodian', 'c': 'country', 'b': 'address', 'e': 'provenance', 'd': 'title', 'n': 'note', '3': 'materials_specified', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 biographical_or_historical_data:
@@ -2310,7 +2310,7 @@ biographical_or_historical_data:
                 ('545__6', 'linkage'))
         marc, '545..', {'biographical_or_historical_data': value['a'], 'field_link_and_sequence_number': value['8'], 'expansion': value['b'], 'uniform_resource_identifier': value['u'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'545__a': 'biographical_or_historical_data', '545__8': 'field_link_and_sequence_number', '545__b': 'expansion', '545__u': 'uniform_resource_identifier', '545__6': 'linkage'}
+        json_for_marc(), {'a': 'biographical_or_historical_data', '8': 'field_link_and_sequence_number', 'b': 'expansion', 'u': 'uniform_resource_identifier', '6': 'linkage'}
 
 @extend
 language_note:
@@ -2323,7 +2323,7 @@ language_note:
                 ('546__6', 'linkage'))
         marc, '546..', {'language_note': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'information_code_or_alphabet': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'546__a': 'language_note', '546__8': 'field_link_and_sequence_number', '546__3': 'materials_specified', '546__b': 'information_code_or_alphabet', '546__6': 'linkage'}
+        json_for_marc(), {'a': 'language_note', '8': 'field_link_and_sequence_number', '3': 'materials_specified', 'b': 'information_code_or_alphabet', '6': 'linkage'}
 
 @extend
 former_title_complexity_note:
@@ -2334,7 +2334,7 @@ former_title_complexity_note:
                 ('547__6', 'linkage'))
         marc, '547..', {'former_title_complexity_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'547__a': 'former_title_complexity_note', '547__8': 'field_link_and_sequence_number', '547__6': 'linkage'}
+        json_for_marc(), {'a': 'former_title_complexity_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 issuing_body_note:
@@ -2345,7 +2345,7 @@ issuing_body_note:
                 ('550__6', 'linkage'))
         marc, '550..', {'issuing_body_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'550__a': 'issuing_body_note', '550__8': 'field_link_and_sequence_number', '550__6': 'linkage'}
+        json_for_marc(), {'a': 'issuing_body_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 entity_and_attribute_information_note:
@@ -2373,7 +2373,7 @@ entity_and_attribute_information_note:
                 ('552__z', 'display_note'))
         marc, '552..', {'entity_type_label': value['a'], 'attribute_label': value['c'], 'entity_type_definition_and_source': value['b'], 'enumerated_domain_value': value['e'], 'attribute_definition_and_source': value['d'], 'range_domain_minimum_and_maximum': value['g'], 'enumerated_domain_value_definition_and_source': value['f'], 'unrepresentable_domain': value['i'], 'codeset_name_and_source': value['h'], 'beginning_and_ending_date_of_attribute_values': value['k'], 'attribute_units_of_measurement_and_resolution': value['j'], 'attribute_value_accuracy_explanation': value['m'], 'attribute_value_accuracy': value['l'], 'entity_and_attribute_overview': value['o'], 'attribute_measurement_frequency': value['n'], 'entity_and_attribute_detail_citation': value['p'], 'uniform_resource_identifier': value['u'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'display_note': value['z']}
     producer:
-        json_for_marc(), {'552__a': 'entity_type_label', '552__c': 'attribute_label', '552__b': 'entity_type_definition_and_source', '552__e': 'enumerated_domain_value', '552__d': 'attribute_definition_and_source', '552__g': 'range_domain_minimum_and_maximum', '552__f': 'enumerated_domain_value_definition_and_source', '552__i': 'unrepresentable_domain', '552__h': 'codeset_name_and_source', '552__k': 'beginning_and_ending_date_of_attribute_values', '552__j': 'attribute_units_of_measurement_and_resolution', '552__m': 'attribute_value_accuracy_explanation', '552__l': 'attribute_value_accuracy', '552__o': 'entity_and_attribute_overview', '552__n': 'attribute_measurement_frequency', '552__p': 'entity_and_attribute_detail_citation', '552__u': 'uniform_resource_identifier', '552__6': 'linkage', '552__8': 'field_link_and_sequence_number', '552__z': 'display_note'}
+        json_for_marc(), {'a': 'entity_type_label', 'c': 'attribute_label', 'b': 'entity_type_definition_and_source', 'e': 'enumerated_domain_value', 'd': 'attribute_definition_and_source', 'g': 'range_domain_minimum_and_maximum', 'f': 'enumerated_domain_value_definition_and_source', 'i': 'unrepresentable_domain', 'h': 'codeset_name_and_source', 'k': 'beginning_and_ending_date_of_attribute_values', 'j': 'attribute_units_of_measurement_and_resolution', 'm': 'attribute_value_accuracy_explanation', 'l': 'attribute_value_accuracy', 'o': 'entity_and_attribute_overview', 'n': 'attribute_measurement_frequency', 'p': 'entity_and_attribute_detail_citation', 'u': 'uniform_resource_identifier', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'display_note'}
 
 @extend
 cumulative_index_finding_aids_note:
@@ -2389,7 +2389,7 @@ cumulative_index_finding_aids_note:
                 ('555__8', 'field_link_and_sequence_number'))
         marc, '555..', {'cumulative_index_finding_aids_note': value['a'], 'degree_of_control': value['c'], 'availability_source': value['b'], 'bibliographic_reference': value['d'], 'materials_specified': value['3'], 'uniform_resource_identifier': value['u'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'555__a': 'cumulative_index_finding_aids_note', '555__c': 'degree_of_control', '555__b': 'availability_source', '555__d': 'bibliographic_reference', '555__3': 'materials_specified', '555__u': 'uniform_resource_identifier', '555__6': 'linkage', '555__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'cumulative_index_finding_aids_note', 'c': 'degree_of_control', 'b': 'availability_source', 'd': 'bibliographic_reference', '3': 'materials_specified', 'u': 'uniform_resource_identifier', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 information_about_documentation_note:
@@ -2401,7 +2401,7 @@ information_about_documentation_note:
                 ('556__6', 'linkage'))
         marc, '556..', {'information_about_documentation_note': value['a'], 'field_link_and_sequence_number': value['8'], 'international_standard_book_number': value['z'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'556__a': 'information_about_documentation_note', '556__8': 'field_link_and_sequence_number', '556__z': 'international_standard_book_number', '556__6': 'linkage'}
+        json_for_marc(), {'a': 'information_about_documentation_note', '8': 'field_link_and_sequence_number', 'z': 'international_standard_book_number', '6': 'linkage'}
 
 @extend
 ownership_and_custodial_history:
@@ -2415,7 +2415,7 @@ ownership_and_custodial_history:
                 ('561__u', 'uniform_resource_identifier'))
         marc, '561..', {'history': value['a'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'uniform_resource_identifier': value['u']}
     producer:
-        json_for_marc(), {'561__a': 'history', '561__3': 'materials_specified', '561__5': 'institution_to_which_field_applies', '561__6': 'linkage', '561__8': 'field_link_and_sequence_number', '561__u': 'uniform_resource_identifier'}
+        json_for_marc(), {'a': 'history', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number', 'u': 'uniform_resource_identifier'}
 
 @extend
 copy_and_version_identification_note:
@@ -2432,7 +2432,7 @@ copy_and_version_identification_note:
                 ('562__8', 'field_link_and_sequence_number'))
         marc, '562..', {'identifying_markings': value['a'], 'version_identification': value['c'], 'copy_identification': value['b'], 'number_of_copies': value['e'], 'presentation_format': value['d'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'562__a': 'identifying_markings', '562__c': 'version_identification', '562__b': 'copy_identification', '562__e': 'number_of_copies', '562__d': 'presentation_format', '562__3': 'materials_specified', '562__5': 'institution_to_which_field_applies', '562__6': 'linkage', '562__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'identifying_markings', 'c': 'version_identification', 'b': 'copy_identification', 'e': 'number_of_copies', 'd': 'presentation_format', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 binding_information:
@@ -2446,7 +2446,7 @@ binding_information:
                 ('563__u', 'uniform_resource_identifier'))
         marc, '563..', {'binding_note': value['a'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'uniform_resource_identifier': value['u']}
     producer:
-        json_for_marc(), {'563__a': 'binding_note', '563__3': 'materials_specified', '563__5': 'institution_to_which_field_applies', '563__6': 'linkage', '563__8': 'field_link_and_sequence_number', '563__u': 'uniform_resource_identifier'}
+        json_for_marc(), {'a': 'binding_note', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number', 'u': 'uniform_resource_identifier'}
 
 @extend
 case_file_characteristics_note:
@@ -2462,7 +2462,7 @@ case_file_characteristics_note:
                 ('565__8', 'field_link_and_sequence_number'))
         marc, '565..', {'number_of_cases_variables': value['a'], 'unit_of_analysis': value['c'], 'name_of_variable': value['b'], 'filing_scheme_or_code': value['e'], 'universe_of_data': value['d'], 'materials_specified': value['3'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'565__a': 'number_of_cases_variables', '565__c': 'unit_of_analysis', '565__b': 'name_of_variable', '565__e': 'filing_scheme_or_code', '565__d': 'universe_of_data', '565__3': 'materials_specified', '565__6': 'linkage', '565__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'number_of_cases_variables', 'c': 'unit_of_analysis', 'b': 'name_of_variable', 'e': 'filing_scheme_or_code', 'd': 'universe_of_data', '3': 'materials_specified', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 methodology_note:
@@ -2473,7 +2473,7 @@ methodology_note:
                 ('567__6', 'linkage'))
         marc, '567..', {'methodology_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'567__a': 'methodology_note', '567__8': 'field_link_and_sequence_number', '567__6': 'linkage'}
+        json_for_marc(), {'a': 'methodology_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 linking_entry_complexity_note:
@@ -2484,7 +2484,7 @@ linking_entry_complexity_note:
                 ('580__6', 'linkage'))
         marc, '580..', {'linking_entry_complexity_note': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'580__a': 'linking_entry_complexity_note', '580__8': 'field_link_and_sequence_number', '580__6': 'linkage'}
+        json_for_marc(), {'a': 'linking_entry_complexity_note', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 publications_about_described_materials_note:
@@ -2497,7 +2497,7 @@ publications_about_described_materials_note:
                 ('581__6', 'linkage'))
         marc, '581..', {'publications_about_described_materials_note': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'international_standard_book_number': value['z'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'581__a': 'publications_about_described_materials_note', '581__8': 'field_link_and_sequence_number', '581__3': 'materials_specified', '581__z': 'international_standard_book_number', '581__6': 'linkage'}
+        json_for_marc(), {'a': 'publications_about_described_materials_note', '8': 'field_link_and_sequence_number', '3': 'materials_specified', 'z': 'international_standard_book_number', '6': 'linkage'}
 
 @extend
 action_note:
@@ -2526,7 +2526,7 @@ action_note:
                 ('583__u', 'uniform_resource_identifier'))
         marc, '583..', {'action': value['a'], 'nonpublic_note': value['x'], 'time_date_of_action': value['c'], 'action_identification': value['b'], 'contingency_for_action': value['e'], 'action_interval': value['d'], 'authorization': value['f'], 'method_of_action': value['i'], 'jurisdiction': value['h'], 'action_agent': value['k'], 'site_of_action': value['j'], 'status': value['l'], 'type_of_unit': value['o'], 'extent': value['n'], 'materials_specified': value['3'], 'source_of_term': value['2'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'public_note': value['z'], 'uniform_resource_identifier': value['u']}
     producer:
-        json_for_marc(), {'583__a': 'action', '583__x': 'nonpublic_note', '583__c': 'time_date_of_action', '583__b': 'action_identification', '583__e': 'contingency_for_action', '583__d': 'action_interval', '583__f': 'authorization', '583__i': 'method_of_action', '583__h': 'jurisdiction', '583__k': 'action_agent', '583__j': 'site_of_action', '583__l': 'status', '583__o': 'type_of_unit', '583__n': 'extent', '583__3': 'materials_specified', '583__2': 'source_of_term', '583__5': 'institution_to_which_field_applies', '583__6': 'linkage', '583__8': 'field_link_and_sequence_number', '583__z': 'public_note', '583__u': 'uniform_resource_identifier'}
+        json_for_marc(), {'a': 'action', 'x': 'nonpublic_note', 'c': 'time_date_of_action', 'b': 'action_identification', 'e': 'contingency_for_action', 'd': 'action_interval', 'f': 'authorization', 'i': 'method_of_action', 'h': 'jurisdiction', 'k': 'action_agent', 'j': 'site_of_action', 'l': 'status', 'o': 'type_of_unit', 'n': 'extent', '3': 'materials_specified', '2': 'source_of_term', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'public_note', 'u': 'uniform_resource_identifier'}
 
 @extend
 accumulation_and_frequency_of_use_note:
@@ -2540,7 +2540,7 @@ accumulation_and_frequency_of_use_note:
                 ('584__8', 'field_link_and_sequence_number'))
         marc, '584..', {'accumulation': value['a'], 'frequency_of_use': value['b'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'584__a': 'accumulation', '584__b': 'frequency_of_use', '584__3': 'materials_specified', '584__5': 'institution_to_which_field_applies', '584__6': 'linkage', '584__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'accumulation', 'b': 'frequency_of_use', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 exhibitions_note:
@@ -2553,7 +2553,7 @@ exhibitions_note:
                 ('585__6', 'linkage'))
         marc, '585..', {'exhibitions_note': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'585__a': 'exhibitions_note', '585__8': 'field_link_and_sequence_number', '585__3': 'materials_specified', '585__5': 'institution_to_which_field_applies', '585__6': 'linkage'}
+        json_for_marc(), {'a': 'exhibitions_note', '8': 'field_link_and_sequence_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '6': 'linkage'}
 
 @extend
 awards_note:
@@ -2565,7 +2565,7 @@ awards_note:
                 ('586__6', 'linkage'))
         marc, '586..', {'awards_note': value['a'], 'field_link_and_sequence_number': value['8'], 'materials_specified': value['3'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'586__a': 'awards_note', '586__8': 'field_link_and_sequence_number', '586__3': 'materials_specified', '586__6': 'linkage'}
+        json_for_marc(), {'a': 'awards_note', '8': 'field_link_and_sequence_number', '3': 'materials_specified', '6': 'linkage'}
 
 @extend
 source_of_description_note:
@@ -2577,7 +2577,7 @@ source_of_description_note:
                 ('588__6', 'linkage'))
         marc, '588..', {'source_of_description_note': value['a'], 'field_link_and_sequence_number': value['8'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'588__a': 'source_of_description_note', '588__8': 'field_link_and_sequence_number', '588__5': 'institution_to_which_field_applies', '588__6': 'linkage'}
+        json_for_marc(), {'a': 'source_of_description_note', '8': 'field_link_and_sequence_number', '5': 'institution_to_which_field_applies', '6': 'linkage'}
 
 @extend
 subject_added_entry_personal_name:
@@ -2615,7 +2615,7 @@ subject_added_entry_personal_name:
                 ('600__z', 'geographic_subdivision'))
         marc, '600..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'personal_name': value['a'], 'titles_and_other_words_associated_with_a_name': value['c'], 'numeration': value['b'], 'relator_term': value['e'], 'dates_associated_with_a_name': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'attribution_qualifier': value['j'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'fuller_form_of_name': value['q'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'form_subdivision': value['v'], 'chronological_subdivision': value['y'], 'general_subdivision': value['x'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'600__0': 'authority_record_control_number', '600__3': 'materials_specified', '600__2': 'source_of_heading_or_term', '600__4': 'relator_code', '600__6': 'linkage', '600__8': 'field_link_and_sequence_number', '600__a': 'personal_name', '600__c': 'titles_and_other_words_associated_with_a_name', '600__b': 'numeration', '600__e': 'relator_term', '600__d': 'dates_associated_with_a_name', '600__g': 'miscellaneous_information', '600__f': 'date_of_a_work', '600__h': 'medium', '600__k': 'form_subheading', '600__j': 'attribution_qualifier', '600__m': 'medium_of_performance_for_music', '600__l': 'language_of_a_work', '600__o': 'arranged_statement_for_music', '600__n': 'number_of_part_section_of_a_work', '600__q': 'fuller_form_of_name', '600__p': 'name_of_part_section_of_a_work', '600__s': 'version', '600__r': 'key_for_music', '600__u': 'affiliation', '600__t': 'title_of_a_work', '600__v': 'form_subdivision', '600__y': 'chronological_subdivision', '600__x': 'general_subdivision', '600__z': 'geographic_subdivision'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'personal_name', 'c': 'titles_and_other_words_associated_with_a_name', 'b': 'numeration', 'e': 'relator_term', 'd': 'dates_associated_with_a_name', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'j': 'attribution_qualifier', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', 'q': 'fuller_form_of_name', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', 'u': 'affiliation', 't': 'title_of_a_work', 'v': 'form_subdivision', 'y': 'chronological_subdivision', 'x': 'general_subdivision', 'z': 'geographic_subdivision'}
 
 @extend
 subject_added_entry_corporate_name:
@@ -2651,7 +2651,7 @@ subject_added_entry_corporate_name:
                 ('610__z', 'geographic_subdivision'))
         marc, '610..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'corporate_name_or_jurisdiction_name_as_entry_element': value['a'], 'location_of_meeting': value['c'], 'subordinate_unit': value['b'], 'relator_term': value['e'], 'date_of_meeting_or_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_meeting': value['n'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'form_subdivision': value['v'], 'chronological_subdivision': value['y'], 'general_subdivision': value['x'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'610__0': 'authority_record_control_number', '610__3': 'materials_specified', '610__2': 'source_of_heading_or_term', '610__4': 'relator_code', '610__6': 'linkage', '610__8': 'field_link_and_sequence_number', '610__a': 'corporate_name_or_jurisdiction_name_as_entry_element', '610__c': 'location_of_meeting', '610__b': 'subordinate_unit', '610__e': 'relator_term', '610__d': 'date_of_meeting_or_treaty_signing', '610__g': 'miscellaneous_information', '610__f': 'date_of_a_work', '610__h': 'medium', '610__k': 'form_subheading', '610__m': 'medium_of_performance_for_music', '610__l': 'language_of_a_work', '610__o': 'arranged_statement_for_music', '610__n': 'number_of_part_section_meeting', '610__p': 'name_of_part_section_of_a_work', '610__s': 'version', '610__r': 'key_for_music', '610__u': 'affiliation', '610__t': 'title_of_a_work', '610__v': 'form_subdivision', '610__y': 'chronological_subdivision', '610__x': 'general_subdivision', '610__z': 'geographic_subdivision'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'corporate_name_or_jurisdiction_name_as_entry_element', 'c': 'location_of_meeting', 'b': 'subordinate_unit', 'e': 'relator_term', 'd': 'date_of_meeting_or_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_meeting', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', 'u': 'affiliation', 't': 'title_of_a_work', 'v': 'form_subdivision', 'y': 'chronological_subdivision', 'x': 'general_subdivision', 'z': 'geographic_subdivision'}
 
 @extend
 subject_added_entry_meeting_name:
@@ -2685,7 +2685,7 @@ subject_added_entry_meeting_name:
                 ('611__z', 'geographic_subdivision'))
         marc, '611..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'meeting_name_or_jurisdiction_name_as_entry_element': value['a'], 'location_of_meeting': value['c'], 'subordinate_unit': value['e'], 'date_of_meeting': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'relator_term': value['j'], 'language_of_a_work': value['l'], 'number_of_part_section_meeting': value['n'], 'name_of_meeting_following_jurisdiction_name_entry_element': value['q'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'form_subdivision': value['v'], 'chronological_subdivision': value['y'], 'general_subdivision': value['x'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'611__0': 'authority_record_control_number', '611__3': 'materials_specified', '611__2': 'source_of_heading_or_term', '611__4': 'relator_code', '611__6': 'linkage', '611__8': 'field_link_and_sequence_number', '611__a': 'meeting_name_or_jurisdiction_name_as_entry_element', '611__c': 'location_of_meeting', '611__e': 'subordinate_unit', '611__d': 'date_of_meeting', '611__g': 'miscellaneous_information', '611__f': 'date_of_a_work', '611__h': 'medium', '611__k': 'form_subheading', '611__j': 'relator_term', '611__l': 'language_of_a_work', '611__n': 'number_of_part_section_meeting', '611__q': 'name_of_meeting_following_jurisdiction_name_entry_element', '611__p': 'name_of_part_section_of_a_work', '611__s': 'version', '611__u': 'affiliation', '611__t': 'title_of_a_work', '611__v': 'form_subdivision', '611__y': 'chronological_subdivision', '611__x': 'general_subdivision', '611__z': 'geographic_subdivision'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'meeting_name_or_jurisdiction_name_as_entry_element', 'c': 'location_of_meeting', 'e': 'subordinate_unit', 'd': 'date_of_meeting', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'j': 'relator_term', 'l': 'language_of_a_work', 'n': 'number_of_part_section_meeting', 'q': 'name_of_meeting_following_jurisdiction_name_entry_element', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'u': 'affiliation', 't': 'title_of_a_work', 'v': 'form_subdivision', 'y': 'chronological_subdivision', 'x': 'general_subdivision', 'z': 'geographic_subdivision'}
 
 @extend
 subject_added_entry_uniform_title:
@@ -2718,7 +2718,7 @@ subject_added_entry_uniform_title:
                 ('630__z', 'geographic_subdivision'))
         marc, '630..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'uniform_title': value['a'], 'relator_term': value['e'], 'date_of_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'title_of_a_work': value['t'], 'form_subdivision': value['v'], 'chronological_subdivision': value['y'], 'general_subdivision': value['x'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'630__0': 'authority_record_control_number', '630__3': 'materials_specified', '630__2': 'source_of_heading_or_term', '630__4': 'relator_code', '630__6': 'linkage', '630__8': 'field_link_and_sequence_number', '630__a': 'uniform_title', '630__e': 'relator_term', '630__d': 'date_of_treaty_signing', '630__g': 'miscellaneous_information', '630__f': 'date_of_a_work', '630__h': 'medium', '630__k': 'form_subheading', '630__m': 'medium_of_performance_for_music', '630__l': 'language_of_a_work', '630__o': 'arranged_statement_for_music', '630__n': 'number_of_part_section_of_a_work', '630__p': 'name_of_part_section_of_a_work', '630__s': 'version', '630__r': 'key_for_music', '630__t': 'title_of_a_work', '630__v': 'form_subdivision', '630__y': 'chronological_subdivision', '630__x': 'general_subdivision', '630__z': 'geographic_subdivision'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'uniform_title', 'e': 'relator_term', 'd': 'date_of_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', 't': 'title_of_a_work', 'v': 'form_subdivision', 'y': 'chronological_subdivision', 'x': 'general_subdivision', 'z': 'geographic_subdivision'}
 
 @extend
 subject_added_entry_chronological_term:
@@ -2736,7 +2736,7 @@ subject_added_entry_chronological_term:
                 ('648__z', 'geographic_subdivision'))
         marc, '648..', {'chronological_term': value['a'], 'general_subdivision': value['x'], 'form_subdivision': value['v'], 'authority_record_control_number_or_standard_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'linkage': value['6'], 'chronological_subdivision': value['y'], 'field_link_and_sequence_number': value['8'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'648__a': 'chronological_term', '648__x': 'general_subdivision', '648__v': 'form_subdivision', '648__0': 'authority_record_control_number_or_standard_number', '648__3': 'materials_specified', '648__2': 'source_of_heading_or_term', '648__6': 'linkage', '648__y': 'chronological_subdivision', '648__8': 'field_link_and_sequence_number', '648__z': 'geographic_subdivision'}
+        json_for_marc(), {'a': 'chronological_term', 'x': 'general_subdivision', 'v': 'form_subdivision', '0': 'authority_record_control_number_or_standard_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '6': 'linkage', 'y': 'chronological_subdivision', '8': 'field_link_and_sequence_number', 'z': 'geographic_subdivision'}
 
 @extend
 subject_added_entry_topical_term:
@@ -2759,7 +2759,7 @@ subject_added_entry_topical_term:
                 ('650__z', 'geographic_subdivision'))
         marc, '650..', {'topical_term_or_geographic_name_entry_element': value['a'], 'general_subdivision': value['x'], 'location_of_event': value['c'], 'topical_term_following_geographic_name_entry_element': value['b'], 'relator_term': value['e'], 'active_dates': value['d'], 'form_subdivision': value['v'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'chronological_subdivision': value['y'], 'field_link_and_sequence_number': value['8'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'650__a': 'topical_term_or_geographic_name_entry_element', '650__x': 'general_subdivision', '650__c': 'location_of_event', '650__b': 'topical_term_following_geographic_name_entry_element', '650__e': 'relator_term', '650__d': 'active_dates', '650__v': 'form_subdivision', '650__0': 'authority_record_control_number', '650__3': 'materials_specified', '650__2': 'source_of_heading_or_term', '650__4': 'relator_code', '650__6': 'linkage', '650__y': 'chronological_subdivision', '650__8': 'field_link_and_sequence_number', '650__z': 'geographic_subdivision'}
+        json_for_marc(), {'a': 'topical_term_or_geographic_name_entry_element', 'x': 'general_subdivision', 'c': 'location_of_event', 'b': 'topical_term_following_geographic_name_entry_element', 'e': 'relator_term', 'd': 'active_dates', 'v': 'form_subdivision', '0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', 'y': 'chronological_subdivision', '8': 'field_link_and_sequence_number', 'z': 'geographic_subdivision'}
 
 @extend
 subject_added_entry_geographic_name:
@@ -2779,7 +2779,7 @@ subject_added_entry_geographic_name:
                 ('651__z', 'geographic_subdivision'))
         marc, '651..', {'geographic_name': value['a'], 'general_subdivision': value['x'], 'relator_term': value['e'], 'form_subdivision': value['v'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'chronological_subdivision': value['y'], 'field_link_and_sequence_number': value['8'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'651__a': 'geographic_name', '651__x': 'general_subdivision', '651__e': 'relator_term', '651__v': 'form_subdivision', '651__0': 'authority_record_control_number', '651__3': 'materials_specified', '651__2': 'source_of_heading_or_term', '651__4': 'relator_code', '651__6': 'linkage', '651__y': 'chronological_subdivision', '651__8': 'field_link_and_sequence_number', '651__z': 'geographic_subdivision'}
+        json_for_marc(), {'a': 'geographic_name', 'x': 'general_subdivision', 'e': 'relator_term', 'v': 'form_subdivision', '0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', 'y': 'chronological_subdivision', '8': 'field_link_and_sequence_number', 'z': 'geographic_subdivision'}
 
 @extend
 index_term_uncontrolled:
@@ -2790,7 +2790,7 @@ index_term_uncontrolled:
                 ('653__6', 'linkage'))
         marc, '653..', {'uncontrolled_term': value['a'], 'field_link_and_sequence_number': value['8'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'653__a': 'uncontrolled_term', '653__8': 'field_link_and_sequence_number', '653__6': 'linkage'}
+        json_for_marc(), {'a': 'uncontrolled_term', '8': 'field_link_and_sequence_number', '6': 'linkage'}
 
 @extend
 subject_added_entry_faceted_topical_terms:
@@ -2811,7 +2811,7 @@ subject_added_entry_faceted_topical_terms:
                 ('654__z', 'geographic_subdivision'))
         marc, '654..', {'focus_term': value['a'], 'facet_hierarchy_designation': value['c'], 'non_focus_term': value['b'], 'relator_term': value['e'], 'form_subdivision': value['v'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'chronological_subdivision': value['y'], 'field_link_and_sequence_number': value['8'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'654__a': 'focus_term', '654__c': 'facet_hierarchy_designation', '654__b': 'non_focus_term', '654__e': 'relator_term', '654__v': 'form_subdivision', '654__0': 'authority_record_control_number', '654__3': 'materials_specified', '654__2': 'source_of_heading_or_term', '654__4': 'relator_code', '654__6': 'linkage', '654__y': 'chronological_subdivision', '654__8': 'field_link_and_sequence_number', '654__z': 'geographic_subdivision'}
+        json_for_marc(), {'a': 'focus_term', 'c': 'facet_hierarchy_designation', 'b': 'non_focus_term', 'e': 'relator_term', 'v': 'form_subdivision', '0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', 'y': 'chronological_subdivision', '8': 'field_link_and_sequence_number', 'z': 'geographic_subdivision'}
 
 @extend
 index_term_genre_form:
@@ -2832,7 +2832,7 @@ index_term_genre_form:
                 ('655__z', 'geographic_subdivision'))
         marc, '655..', {'genre_form_data_or_focus_term': value['a'], 'general_subdivision': value['x'], 'facet_hierarchy_designation': value['c'], 'non_focus_term': value['b'], 'form_subdivision': value['v'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_term': value['2'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'chronological_subdivision': value['y'], 'field_link_and_sequence_number': value['8'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'655__a': 'genre_form_data_or_focus_term', '655__x': 'general_subdivision', '655__c': 'facet_hierarchy_designation', '655__b': 'non_focus_term', '655__v': 'form_subdivision', '655__0': 'authority_record_control_number', '655__3': 'materials_specified', '655__2': 'source_of_term', '655__5': 'institution_to_which_field_applies', '655__6': 'linkage', '655__y': 'chronological_subdivision', '655__8': 'field_link_and_sequence_number', '655__z': 'geographic_subdivision'}
+        json_for_marc(), {'a': 'genre_form_data_or_focus_term', 'x': 'general_subdivision', 'c': 'facet_hierarchy_designation', 'b': 'non_focus_term', 'v': 'form_subdivision', '0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_term', '5': 'institution_to_which_field_applies', '6': 'linkage', 'y': 'chronological_subdivision', '8': 'field_link_and_sequence_number', 'z': 'geographic_subdivision'}
 
 @extend
 index_term_occupation:
@@ -2851,7 +2851,7 @@ index_term_occupation:
                 ('656__z', 'geographic_subdivision'))
         marc, '656..', {'occupation': value['a'], 'general_subdivision': value['x'], 'form': value['k'], 'form_subdivision': value['v'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_term': value['2'], 'linkage': value['6'], 'chronological_subdivision': value['y'], 'field_link_and_sequence_number': value['8'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'656__a': 'occupation', '656__x': 'general_subdivision', '656__k': 'form', '656__v': 'form_subdivision', '656__0': 'authority_record_control_number', '656__3': 'materials_specified', '656__2': 'source_of_term', '656__6': 'linkage', '656__y': 'chronological_subdivision', '656__8': 'field_link_and_sequence_number', '656__z': 'geographic_subdivision'}
+        json_for_marc(), {'a': 'occupation', 'x': 'general_subdivision', 'k': 'form', 'v': 'form_subdivision', '0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_term', '6': 'linkage', 'y': 'chronological_subdivision', '8': 'field_link_and_sequence_number', 'z': 'geographic_subdivision'}
 
 @extend
 index_term_function:
@@ -2869,7 +2869,7 @@ index_term_function:
                 ('657__z', 'geographic_subdivision'))
         marc, '657..', {'function': value['a'], 'general_subdivision': value['x'], 'form_subdivision': value['v'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_term': value['2'], 'linkage': value['6'], 'chronological_subdivision': value['y'], 'field_link_and_sequence_number': value['8'], 'geographic_subdivision': value['z']}
     producer:
-        json_for_marc(), {'657__a': 'function', '657__x': 'general_subdivision', '657__v': 'form_subdivision', '657__0': 'authority_record_control_number', '657__3': 'materials_specified', '657__2': 'source_of_term', '657__6': 'linkage', '657__y': 'chronological_subdivision', '657__8': 'field_link_and_sequence_number', '657__z': 'geographic_subdivision'}
+        json_for_marc(), {'a': 'function', 'x': 'general_subdivision', 'v': 'form_subdivision', '0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_term', '6': 'linkage', 'y': 'chronological_subdivision', '8': 'field_link_and_sequence_number', 'z': 'geographic_subdivision'}
 
 @extend
 index_term_curriculum_objective:
@@ -2884,7 +2884,7 @@ index_term_curriculum_objective:
                 ('658__8', 'field_link_and_sequence_number'))
         marc, '658..', {'main_curriculum_objective': value['a'], 'curriculum_code': value['c'], 'subordinate_curriculum_objective': value['b'], 'correlation_factor': value['d'], 'source_of_term_or_code': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'658__a': 'main_curriculum_objective', '658__c': 'curriculum_code', '658__b': 'subordinate_curriculum_objective', '658__d': 'correlation_factor', '658__2': 'source_of_term_or_code', '658__6': 'linkage', '658__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'main_curriculum_objective', 'c': 'curriculum_code', 'b': 'subordinate_curriculum_objective', 'd': 'correlation_factor', '2': 'source_of_term_or_code', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 subject_added_entry_hierarchical_place_name:
@@ -2905,7 +2905,7 @@ subject_added_entry_hierarchical_place_name:
                 ('662__8', 'field_link_and_sequence_number'))
         marc, '662..', {'country_or_larger_entity': value['a'], 'intermediate_political_jurisdiction': value['c'], 'first_order_political_jurisdiction': value['b'], 'relator_term': value['e'], 'city': value['d'], 'other_nonjurisdictional_geographic_region_and_feature': value['g'], 'city_subsection': value['f'], 'extraterrestrial_area': value['h'], 'authority_record_control_number': value['0'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'662__a': 'country_or_larger_entity', '662__c': 'intermediate_political_jurisdiction', '662__b': 'first_order_political_jurisdiction', '662__e': 'relator_term', '662__d': 'city', '662__g': 'other_nonjurisdictional_geographic_region_and_feature', '662__f': 'city_subsection', '662__h': 'extraterrestrial_area', '662__0': 'authority_record_control_number', '662__2': 'source_of_heading_or_term', '662__4': 'relator_code', '662__6': 'linkage', '662__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'country_or_larger_entity', 'c': 'intermediate_political_jurisdiction', 'b': 'first_order_political_jurisdiction', 'e': 'relator_term', 'd': 'city', 'g': 'other_nonjurisdictional_geographic_region_and_feature', 'f': 'city_subsection', 'h': 'extraterrestrial_area', '0': 'authority_record_control_number', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 added_entry_personal_name:
@@ -2941,7 +2941,7 @@ added_entry_personal_name:
                 ('700__x', 'international_standard_serial_number'))
         marc, '700..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'personal_name': value['a'], 'titles_and_other_words_associated_with_a_name': value['c'], 'numeration': value['b'], 'relator_term': value['e'], 'dates_associated_with_a_name': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'relationship_information': value['i'], 'medium': value['h'], 'form_subheading': value['k'], 'attribution_qualifier': value['j'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'fuller_form_of_name': value['q'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'international_standard_serial_number': value['x']}
     producer:
-        json_for_marc(), {'700__0': 'authority_record_control_number', '700__3': 'materials_specified', '700__5': 'institution_to_which_field_applies', '700__4': 'relator_code', '700__6': 'linkage', '700__8': 'field_link_and_sequence_number', '700__a': 'personal_name', '700__c': 'titles_and_other_words_associated_with_a_name', '700__b': 'numeration', '700__e': 'relator_term', '700__d': 'dates_associated_with_a_name', '700__g': 'miscellaneous_information', '700__f': 'date_of_a_work', '700__i': 'relationship_information', '700__h': 'medium', '700__k': 'form_subheading', '700__j': 'attribution_qualifier', '700__m': 'medium_of_performance_for_music', '700__l': 'language_of_a_work', '700__o': 'arranged_statement_for_music', '700__n': 'number_of_part_section_of_a_work', '700__q': 'fuller_form_of_name', '700__p': 'name_of_part_section_of_a_work', '700__s': 'version', '700__r': 'key_for_music', '700__u': 'affiliation', '700__t': 'title_of_a_work', '700__x': 'international_standard_serial_number'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'personal_name', 'c': 'titles_and_other_words_associated_with_a_name', 'b': 'numeration', 'e': 'relator_term', 'd': 'dates_associated_with_a_name', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'i': 'relationship_information', 'h': 'medium', 'k': 'form_subheading', 'j': 'attribution_qualifier', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', 'q': 'fuller_form_of_name', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', 'u': 'affiliation', 't': 'title_of_a_work', 'x': 'international_standard_serial_number'}
 
 @extend
 added_entry_corporate_name:
@@ -2975,7 +2975,7 @@ added_entry_corporate_name:
                 ('710__x', 'international_standard_serial_number'))
         marc, '710..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'corporate_name_or_jurisdiction_name_as_entry_element': value['a'], 'location_of_meeting': value['c'], 'subordinate_unit': value['b'], 'relator_term': value['e'], 'date_of_meeting_or_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'relationship_information': value['i'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_meeting': value['n'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'international_standard_serial_number': value['x']}
     producer:
-        json_for_marc(), {'710__0': 'authority_record_control_number', '710__3': 'materials_specified', '710__5': 'institution_to_which_field_applies', '710__4': 'relator_code', '710__6': 'linkage', '710__8': 'field_link_and_sequence_number', '710__a': 'corporate_name_or_jurisdiction_name_as_entry_element', '710__c': 'location_of_meeting', '710__b': 'subordinate_unit', '710__e': 'relator_term', '710__d': 'date_of_meeting_or_treaty_signing', '710__g': 'miscellaneous_information', '710__f': 'date_of_a_work', '710__i': 'relationship_information', '710__h': 'medium', '710__k': 'form_subheading', '710__m': 'medium_of_performance_for_music', '710__l': 'language_of_a_work', '710__o': 'arranged_statement_for_music', '710__n': 'number_of_part_section_meeting', '710__p': 'name_of_part_section_of_a_work', '710__s': 'version', '710__r': 'key_for_music', '710__u': 'affiliation', '710__t': 'title_of_a_work', '710__x': 'international_standard_serial_number'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'corporate_name_or_jurisdiction_name_as_entry_element', 'c': 'location_of_meeting', 'b': 'subordinate_unit', 'e': 'relator_term', 'd': 'date_of_meeting_or_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'i': 'relationship_information', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_meeting', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', 'u': 'affiliation', 't': 'title_of_a_work', 'x': 'international_standard_serial_number'}
 
 @extend
 added_entry_meeting_name:
@@ -3007,7 +3007,7 @@ added_entry_meeting_name:
                 ('711__x', 'international_standard_serial_number'))
         marc, '711..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'meeting_name_or_jurisdiction_name_as_entry_element': value['a'], 'location_of_meeting': value['c'], 'subordinate_unit': value['e'], 'date_of_meeting': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'relationship_information': value['i'], 'medium': value['h'], 'form_subheading': value['k'], 'relator_term': value['j'], 'language_of_a_work': value['l'], 'number_of_part_section_meeting': value['n'], 'name_of_meeting_following_jurisdiction_name_entry_element': value['q'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'international_standard_serial_number': value['x']}
     producer:
-        json_for_marc(), {'711__0': 'authority_record_control_number', '711__3': 'materials_specified', '711__5': 'institution_to_which_field_applies', '711__4': 'relator_code', '711__6': 'linkage', '711__8': 'field_link_and_sequence_number', '711__a': 'meeting_name_or_jurisdiction_name_as_entry_element', '711__c': 'location_of_meeting', '711__e': 'subordinate_unit', '711__d': 'date_of_meeting', '711__g': 'miscellaneous_information', '711__f': 'date_of_a_work', '711__i': 'relationship_information', '711__h': 'medium', '711__k': 'form_subheading', '711__j': 'relator_term', '711__l': 'language_of_a_work', '711__n': 'number_of_part_section_meeting', '711__q': 'name_of_meeting_following_jurisdiction_name_entry_element', '711__p': 'name_of_part_section_of_a_work', '711__s': 'version', '711__u': 'affiliation', '711__t': 'title_of_a_work', '711__x': 'international_standard_serial_number'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'meeting_name_or_jurisdiction_name_as_entry_element', 'c': 'location_of_meeting', 'e': 'subordinate_unit', 'd': 'date_of_meeting', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'i': 'relationship_information', 'h': 'medium', 'k': 'form_subheading', 'j': 'relator_term', 'l': 'language_of_a_work', 'n': 'number_of_part_section_meeting', 'q': 'name_of_meeting_following_jurisdiction_name_entry_element', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'u': 'affiliation', 't': 'title_of_a_work', 'x': 'international_standard_serial_number'}
 
 @extend
 added_entry_uncontrolled_name:
@@ -3020,7 +3020,7 @@ added_entry_uncontrolled_name:
                 ('720__6', 'linkage'))
         marc, '720..', {'name': value['a'], 'field_link_and_sequence_number': value['8'], 'relator_term': value['e'], 'relator_code': value['4'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'720__a': 'name', '720__8': 'field_link_and_sequence_number', '720__e': 'relator_term', '720__4': 'relator_code', '720__6': 'linkage'}
+        json_for_marc(), {'a': 'name', '8': 'field_link_and_sequence_number', 'e': 'relator_term', '4': 'relator_code', '6': 'linkage'}
 
 @extend
 added_entry_uniform_title:
@@ -3049,7 +3049,7 @@ added_entry_uniform_title:
                 ('730__s', 'version'))
         marc, '730..', {'uniform_title': value['a'], 'international_standard_serial_number': value['x'], 'name_of_part_section_of_a_work': value['p'], 'date_of_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'relationship_information': value['i'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'key_for_music': value['r'], 'institution_to_which_field_applies': value['5'], 'title_of_a_work': value['t'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'version': value['s']}
     producer:
-        json_for_marc(), {'730__a': 'uniform_title', '730__x': 'international_standard_serial_number', '730__p': 'name_of_part_section_of_a_work', '730__d': 'date_of_treaty_signing', '730__g': 'miscellaneous_information', '730__f': 'date_of_a_work', '730__i': 'relationship_information', '730__h': 'medium', '730__k': 'form_subheading', '730__m': 'medium_of_performance_for_music', '730__l': 'language_of_a_work', '730__o': 'arranged_statement_for_music', '730__n': 'number_of_part_section_of_a_work', '730__0': 'authority_record_control_number', '730__3': 'materials_specified', '730__r': 'key_for_music', '730__5': 'institution_to_which_field_applies', '730__t': 'title_of_a_work', '730__6': 'linkage', '730__8': 'field_link_and_sequence_number', '730__s': 'version'}
+        json_for_marc(), {'a': 'uniform_title', 'x': 'international_standard_serial_number', 'p': 'name_of_part_section_of_a_work', 'd': 'date_of_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'i': 'relationship_information', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', '0': 'authority_record_control_number', '3': 'materials_specified', 'r': 'key_for_music', '5': 'institution_to_which_field_applies', 't': 'title_of_a_work', '6': 'linkage', '8': 'field_link_and_sequence_number', 's': 'version'}
 
 @extend
 added_entry_uncontrolled_related_analytical_title:
@@ -3064,7 +3064,7 @@ added_entry_uncontrolled_related_analytical_title:
                 ('740__8', 'field_link_and_sequence_number'))
         marc, '740..', {'uncontrolled_related_analytical_title': value['a'], 'medium': value['h'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'institution_to_which_field_applies': value['5'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'740__a': 'uncontrolled_related_analytical_title', '740__h': 'medium', '740__n': 'number_of_part_section_of_a_work', '740__p': 'name_of_part_section_of_a_work', '740__5': 'institution_to_which_field_applies', '740__6': 'linkage', '740__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'uncontrolled_related_analytical_title', 'h': 'medium', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', '5': 'institution_to_which_field_applies', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 added_entry_geographic_name:
@@ -3080,7 +3080,7 @@ added_entry_geographic_name:
                 ('751__8', 'field_link_and_sequence_number'))
         marc, '751..', {'geographic_name': value['a'], 'relator_term': value['e'], 'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'source_of_heading_or_term': value['2'], 'relator_code': value['4'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'751__a': 'geographic_name', '751__e': 'relator_term', '751__0': 'authority_record_control_number', '751__3': 'materials_specified', '751__2': 'source_of_heading_or_term', '751__4': 'relator_code', '751__6': 'linkage', '751__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'geographic_name', 'e': 'relator_term', '0': 'authority_record_control_number', '3': 'materials_specified', '2': 'source_of_heading_or_term', '4': 'relator_code', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 added_entry_hierarchical_place_name:
@@ -3099,7 +3099,7 @@ added_entry_hierarchical_place_name:
                 ('752__8', 'field_link_and_sequence_number'))
         marc, '752..', {'country_or_larger_entity': value['a'], 'intermediate_political_jurisdiction': value['c'], 'first_order_political_jurisdiction': value['b'], 'city': value['d'], 'other_nonjurisdictional_geographic_region_and_feature': value['g'], 'city_subsection': value['f'], 'extraterrestrial_area': value['h'], 'authority_record_control_number': value['0'], 'source_of_heading_or_term': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'752__a': 'country_or_larger_entity', '752__c': 'intermediate_political_jurisdiction', '752__b': 'first_order_political_jurisdiction', '752__d': 'city', '752__g': 'other_nonjurisdictional_geographic_region_and_feature', '752__f': 'city_subsection', '752__h': 'extraterrestrial_area', '752__0': 'authority_record_control_number', '752__2': 'source_of_heading_or_term', '752__6': 'linkage', '752__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'country_or_larger_entity', 'c': 'intermediate_political_jurisdiction', 'b': 'first_order_political_jurisdiction', 'd': 'city', 'g': 'other_nonjurisdictional_geographic_region_and_feature', 'f': 'city_subsection', 'h': 'extraterrestrial_area', '0': 'authority_record_control_number', '2': 'source_of_heading_or_term', '6': 'linkage', '8': 'field_link_and_sequence_number'}
 
 @extend
 system_details_access_to_computer_files:
@@ -3112,7 +3112,7 @@ system_details_access_to_computer_files:
                 ('753__6', 'linkage'))
         marc, '753..', {'make_and_model_of_machine': value['a'], 'field_link_and_sequence_number': value['8'], 'operating_system': value['c'], 'programming_language': value['b'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'753__a': 'make_and_model_of_machine', '753__8': 'field_link_and_sequence_number', '753__c': 'operating_system', '753__b': 'programming_language', '753__6': 'linkage'}
+        json_for_marc(), {'a': 'make_and_model_of_machine', '8': 'field_link_and_sequence_number', 'c': 'operating_system', 'b': 'programming_language', '6': 'linkage'}
 
 @extend
 added_entry_taxonomic_identification:
@@ -3129,7 +3129,7 @@ added_entry_taxonomic_identification:
                 ('754__z', 'public_note'))
         marc, '754..', {'taxonomic_name': value['a'], 'non_public_note': value['x'], 'taxonomic_category': value['c'], 'common_or_alternative_name': value['d'], 'authority_record_control_number': value['0'], 'source_of_taxonomic_identification': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'public_note': value['z']}
     producer:
-        json_for_marc(), {'754__a': 'taxonomic_name', '754__x': 'non_public_note', '754__c': 'taxonomic_category', '754__d': 'common_or_alternative_name', '754__0': 'authority_record_control_number', '754__2': 'source_of_taxonomic_identification', '754__6': 'linkage', '754__8': 'field_link_and_sequence_number', '754__z': 'public_note'}
+        json_for_marc(), {'a': 'taxonomic_name', 'x': 'non_public_note', 'c': 'taxonomic_category', 'd': 'common_or_alternative_name', '0': 'authority_record_control_number', '2': 'source_of_taxonomic_identification', '6': 'linkage', '8': 'field_link_and_sequence_number', 'z': 'public_note'}
 
 @extend
 main_series_entry:
@@ -3156,7 +3156,7 @@ main_series_entry:
                 ('760__t', 'title'))
         marc, '760..', {'main_entry_heading': value['a'], 'international_standard_serial_number': value['x'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'record_control_number': value['w'], 'uniform_title': value['s'], 'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'coden_designation': value['y'], 'field_link_and_sequence_number': value['8'], 'title': value['t']}
     producer:
-        json_for_marc(), {'760__a': 'main_entry_heading', '760__x': 'international_standard_serial_number', '760__c': 'qualifying_information', '760__b': 'edition', '760__d': 'place_publisher_and_date_of_publication', '760__g': 'related_parts', '760__i': 'relationship_information', '760__h': 'physical_description', '760__m': 'material_specific_details', '760__o': 'other_item_identifier', '760__n': 'note', '760__w': 'record_control_number', '760__s': 'uniform_title', '760__4': 'relationship_code', '760__7': 'control_subfield', '760__6': 'linkage', '760__y': 'coden_designation', '760__8': 'field_link_and_sequence_number', '760__t': 'title'}
+        json_for_marc(), {'a': 'main_entry_heading', 'x': 'international_standard_serial_number', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 'w': 'record_control_number', 's': 'uniform_title', '4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', 'y': 'coden_designation', '8': 'field_link_and_sequence_number', 't': 'title'}
 
 @extend
 subseries_entry:
@@ -3183,7 +3183,7 @@ subseries_entry:
                 ('762__t', 'title'))
         marc, '762..', {'main_entry_heading': value['a'], 'international_standard_serial_number': value['x'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'record_control_number': value['w'], 'uniform_title': value['s'], 'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'coden_designation': value['y'], 'field_link_and_sequence_number': value['8'], 'title': value['t']}
     producer:
-        json_for_marc(), {'762__a': 'main_entry_heading', '762__x': 'international_standard_serial_number', '762__c': 'qualifying_information', '762__b': 'edition', '762__d': 'place_publisher_and_date_of_publication', '762__g': 'related_parts', '762__i': 'relationship_information', '762__h': 'physical_description', '762__m': 'material_specific_details', '762__o': 'other_item_identifier', '762__n': 'note', '762__w': 'record_control_number', '762__s': 'uniform_title', '762__4': 'relationship_code', '762__7': 'control_subfield', '762__6': 'linkage', '762__y': 'coden_designation', '762__8': 'field_link_and_sequence_number', '762__t': 'title'}
+        json_for_marc(), {'a': 'main_entry_heading', 'x': 'international_standard_serial_number', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 'w': 'record_control_number', 's': 'uniform_title', '4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', 'y': 'coden_designation', '8': 'field_link_and_sequence_number', 't': 'title'}
 
 @extend
 original_language_entry:
@@ -3214,7 +3214,7 @@ original_language_entry:
                 ('765__z', 'international_standard_book_number'))
         marc, '765..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'765__4': 'relationship_code', '765__7': 'control_subfield', '765__6': 'linkage', '765__8': 'field_link_and_sequence_number', '765__a': 'main_entry_heading', '765__c': 'qualifying_information', '765__b': 'edition', '765__d': 'place_publisher_and_date_of_publication', '765__g': 'related_parts', '765__i': 'relationship_information', '765__h': 'physical_description', '765__k': 'series_data_for_related_item', '765__m': 'material_specific_details', '765__o': 'other_item_identifier', '765__n': 'note', '765__s': 'uniform_title', '765__r': 'report_number', '765__u': 'standard_technical_report_number', '765__t': 'title', '765__w': 'record_control_number', '765__y': 'coden_designation', '765__x': 'international_standard_serial_number', '765__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 translation_entry:
@@ -3245,7 +3245,7 @@ translation_entry:
                 ('767__z', 'international_standard_book_number'))
         marc, '767..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'767__4': 'relationship_code', '767__7': 'control_subfield', '767__6': 'linkage', '767__8': 'field_link_and_sequence_number', '767__a': 'main_entry_heading', '767__c': 'qualifying_information', '767__b': 'edition', '767__d': 'place_publisher_and_date_of_publication', '767__g': 'related_parts', '767__i': 'relationship_information', '767__h': 'physical_description', '767__k': 'series_data_for_related_item', '767__m': 'material_specific_details', '767__o': 'other_item_identifier', '767__n': 'note', '767__s': 'uniform_title', '767__r': 'report_number', '767__u': 'standard_technical_report_number', '767__t': 'title', '767__w': 'record_control_number', '767__y': 'coden_designation', '767__x': 'international_standard_serial_number', '767__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 supplement_special_issue_entry:
@@ -3276,7 +3276,7 @@ supplement_special_issue_entry:
                 ('770__z', 'international_standard_book_number'))
         marc, '770..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'770__4': 'relationship_code', '770__7': 'control_subfield', '770__6': 'linkage', '770__8': 'field_link_and_sequence_number', '770__a': 'main_entry_heading', '770__c': 'qualifying_information', '770__b': 'edition', '770__d': 'place_publisher_and_date_of_publication', '770__g': 'related_parts', '770__i': 'relationship_information', '770__h': 'physical_description', '770__k': 'series_data_for_related_item', '770__m': 'material_specific_details', '770__o': 'other_item_identifier', '770__n': 'note', '770__s': 'uniform_title', '770__r': 'report_number', '770__u': 'standard_technical_report_number', '770__t': 'title', '770__w': 'record_control_number', '770__y': 'coden_designation', '770__x': 'international_standard_serial_number', '770__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 supplement_parent_entry:
@@ -3307,7 +3307,7 @@ supplement_parent_entry:
                 ('772__z', 'international_standard_book_number'))
         marc, '772..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'772__4': 'relationship_code', '772__7': 'control_subfield', '772__6': 'linkage', '772__8': 'field_link_and_sequence_number', '772__a': 'main_entry_heading', '772__c': 'qualifying_information', '772__b': 'edition', '772__d': 'place_publisher_and_date_of_publication', '772__g': 'related_parts', '772__i': 'relationship_information', '772__h': 'physical_description', '772__k': 'series_data_for_related_item', '772__m': 'material_specific_details', '772__o': 'other_item_identifier', '772__n': 'note', '772__s': 'uniform_title', '772__r': 'report_number', '772__u': 'standard_technical_report_number', '772__t': 'title', '772__w': 'record_control_number', '772__y': 'coden_designation', '772__x': 'international_standard_serial_number', '772__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 host_item_entry:
@@ -3340,7 +3340,7 @@ host_item_entry:
                 ('773__z', 'international_standard_book_number'))
         marc, '773..', {'materials_specified': value['3'], 'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'enumeration_and_first_page': value['q'], 'abbreviated_title': value['p'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'773__3': 'materials_specified', '773__4': 'relationship_code', '773__7': 'control_subfield', '773__6': 'linkage', '773__8': 'field_link_and_sequence_number', '773__a': 'main_entry_heading', '773__b': 'edition', '773__d': 'place_publisher_and_date_of_publication', '773__g': 'related_parts', '773__i': 'relationship_information', '773__h': 'physical_description', '773__k': 'series_data_for_related_item', '773__m': 'material_specific_details', '773__o': 'other_item_identifier', '773__n': 'note', '773__q': 'enumeration_and_first_page', '773__p': 'abbreviated_title', '773__s': 'uniform_title', '773__r': 'report_number', '773__u': 'standard_technical_report_number', '773__t': 'title', '773__w': 'record_control_number', '773__y': 'coden_designation', '773__x': 'international_standard_serial_number', '773__z': 'international_standard_book_number'}
+        json_for_marc(), {'3': 'materials_specified', '4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 'q': 'enumeration_and_first_page', 'p': 'abbreviated_title', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 constituent_unit_entry:
@@ -3371,7 +3371,7 @@ constituent_unit_entry:
                 ('774__z', 'international_standard_book_number'))
         marc, '774..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'774__4': 'relationship_code', '774__7': 'control_subfield', '774__6': 'linkage', '774__8': 'field_link_and_sequence_number', '774__a': 'main_entry_heading', '774__c': 'qualifying_information', '774__b': 'edition', '774__d': 'place_publisher_and_date_of_publication', '774__g': 'related_parts', '774__i': 'relationship_information', '774__h': 'physical_description', '774__k': 'series_data_for_related_item', '774__m': 'material_specific_details', '774__o': 'other_item_identifier', '774__n': 'note', '774__s': 'uniform_title', '774__r': 'report_number', '774__u': 'standard_technical_report_number', '774__t': 'title', '774__w': 'record_control_number', '774__y': 'coden_designation', '774__x': 'international_standard_serial_number', '774__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 other_edition_entry:
@@ -3404,7 +3404,7 @@ other_edition_entry:
                 ('775__z', 'international_standard_book_number'))
         marc, '775..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'language_code': value['e'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'country_code': value['f'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'775__4': 'relationship_code', '775__7': 'control_subfield', '775__6': 'linkage', '775__8': 'field_link_and_sequence_number', '775__a': 'main_entry_heading', '775__c': 'qualifying_information', '775__b': 'edition', '775__e': 'language_code', '775__d': 'place_publisher_and_date_of_publication', '775__g': 'related_parts', '775__f': 'country_code', '775__i': 'relationship_information', '775__h': 'physical_description', '775__k': 'series_data_for_related_item', '775__m': 'material_specific_details', '775__o': 'other_item_identifier', '775__n': 'note', '775__s': 'uniform_title', '775__r': 'report_number', '775__u': 'standard_technical_report_number', '775__t': 'title', '775__w': 'record_control_number', '775__y': 'coden_designation', '775__x': 'international_standard_serial_number', '775__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'e': 'language_code', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'f': 'country_code', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 additional_physical_form_entry:
@@ -3435,7 +3435,7 @@ additional_physical_form_entry:
                 ('776__z', 'international_standard_book_number'))
         marc, '776..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'776__4': 'relationship_code', '776__7': 'control_subfield', '776__6': 'linkage', '776__8': 'field_link_and_sequence_number', '776__a': 'main_entry_heading', '776__c': 'qualifying_information', '776__b': 'edition', '776__d': 'place_publisher_and_date_of_publication', '776__g': 'related_parts', '776__i': 'relationship_information', '776__h': 'physical_description', '776__k': 'series_data_for_related_item', '776__m': 'material_specific_details', '776__o': 'other_item_identifier', '776__n': 'note', '776__s': 'uniform_title', '776__r': 'report_number', '776__u': 'standard_technical_report_number', '776__t': 'title', '776__w': 'record_control_number', '776__y': 'coden_designation', '776__x': 'international_standard_serial_number', '776__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 issued_with_entry:
@@ -3463,7 +3463,7 @@ issued_with_entry:
                 ('777__t', 'title'))
         marc, '777..', {'main_entry_heading': value['a'], 'international_standard_serial_number': value['x'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'record_control_number': value['w'], 'uniform_title': value['s'], 'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'coden_designation': value['y'], 'field_link_and_sequence_number': value['8'], 'title': value['t']}
     producer:
-        json_for_marc(), {'777__a': 'main_entry_heading', '777__x': 'international_standard_serial_number', '777__c': 'qualifying_information', '777__b': 'edition', '777__d': 'place_publisher_and_date_of_publication', '777__g': 'related_parts', '777__i': 'relationship_information', '777__h': 'physical_description', '777__k': 'series_data_for_related_item', '777__m': 'material_specific_details', '777__o': 'other_item_identifier', '777__n': 'note', '777__w': 'record_control_number', '777__s': 'uniform_title', '777__4': 'relationship_code', '777__7': 'control_subfield', '777__6': 'linkage', '777__y': 'coden_designation', '777__8': 'field_link_and_sequence_number', '777__t': 'title'}
+        json_for_marc(), {'a': 'main_entry_heading', 'x': 'international_standard_serial_number', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 'w': 'record_control_number', 's': 'uniform_title', '4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', 'y': 'coden_designation', '8': 'field_link_and_sequence_number', 't': 'title'}
 
 @extend
 preceding_entry:
@@ -3494,7 +3494,7 @@ preceding_entry:
                 ('780__z', 'international_standard_book_number'))
         marc, '780..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'780__4': 'relationship_code', '780__7': 'control_subfield', '780__6': 'linkage', '780__8': 'field_link_and_sequence_number', '780__a': 'main_entry_heading', '780__c': 'qualifying_information', '780__b': 'edition', '780__d': 'place_publisher_and_date_of_publication', '780__g': 'related_parts', '780__i': 'relationship_information', '780__h': 'physical_description', '780__k': 'series_data_for_related_item', '780__m': 'material_specific_details', '780__o': 'other_item_identifier', '780__n': 'note', '780__s': 'uniform_title', '780__r': 'report_number', '780__u': 'standard_technical_report_number', '780__t': 'title', '780__w': 'record_control_number', '780__y': 'coden_designation', '780__x': 'international_standard_serial_number', '780__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 succeeding_entry:
@@ -3525,7 +3525,7 @@ succeeding_entry:
                 ('785__z', 'international_standard_book_number'))
         marc, '785..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'785__4': 'relationship_code', '785__7': 'control_subfield', '785__6': 'linkage', '785__8': 'field_link_and_sequence_number', '785__a': 'main_entry_heading', '785__c': 'qualifying_information', '785__b': 'edition', '785__d': 'place_publisher_and_date_of_publication', '785__g': 'related_parts', '785__i': 'relationship_information', '785__h': 'physical_description', '785__k': 'series_data_for_related_item', '785__m': 'material_specific_details', '785__o': 'other_item_identifier', '785__n': 'note', '785__s': 'uniform_title', '785__r': 'report_number', '785__u': 'standard_technical_report_number', '785__t': 'title', '785__w': 'record_control_number', '785__y': 'coden_designation', '785__x': 'international_standard_serial_number', '785__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 data_source_entry:
@@ -3559,7 +3559,7 @@ data_source_entry:
                 ('786__z', 'international_standard_book_number'))
         marc, '786..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'period_of_content': value['j'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'abbreviated_title': value['p'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'source_contribution': value['v'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'786__4': 'relationship_code', '786__7': 'control_subfield', '786__6': 'linkage', '786__8': 'field_link_and_sequence_number', '786__a': 'main_entry_heading', '786__c': 'qualifying_information', '786__b': 'edition', '786__d': 'place_publisher_and_date_of_publication', '786__g': 'related_parts', '786__i': 'relationship_information', '786__h': 'physical_description', '786__k': 'series_data_for_related_item', '786__j': 'period_of_content', '786__m': 'material_specific_details', '786__o': 'other_item_identifier', '786__n': 'note', '786__p': 'abbreviated_title', '786__s': 'uniform_title', '786__r': 'report_number', '786__u': 'standard_technical_report_number', '786__t': 'title', '786__w': 'record_control_number', '786__v': 'source_contribution', '786__y': 'coden_designation', '786__x': 'international_standard_serial_number', '786__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'j': 'period_of_content', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 'p': 'abbreviated_title', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'v': 'source_contribution', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 other_relationship_entry:
@@ -3590,7 +3590,7 @@ other_relationship_entry:
                 ('787__z', 'international_standard_book_number'))
         marc, '787..', {'relationship_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'main_entry_heading': value['a'], 'qualifying_information': value['c'], 'edition': value['b'], 'place_publisher_and_date_of_publication': value['d'], 'related_parts': value['g'], 'relationship_information': value['i'], 'physical_description': value['h'], 'series_data_for_related_item': value['k'], 'material_specific_details': value['m'], 'other_item_identifier': value['o'], 'note': value['n'], 'uniform_title': value['s'], 'report_number': value['r'], 'standard_technical_report_number': value['u'], 'title': value['t'], 'record_control_number': value['w'], 'coden_designation': value['y'], 'international_standard_serial_number': value['x'], 'international_standard_book_number': value['z']}
     producer:
-        json_for_marc(), {'787__4': 'relationship_code', '787__7': 'control_subfield', '787__6': 'linkage', '787__8': 'field_link_and_sequence_number', '787__a': 'main_entry_heading', '787__c': 'qualifying_information', '787__b': 'edition', '787__d': 'place_publisher_and_date_of_publication', '787__g': 'related_parts', '787__i': 'relationship_information', '787__h': 'physical_description', '787__k': 'series_data_for_related_item', '787__m': 'material_specific_details', '787__o': 'other_item_identifier', '787__n': 'note', '787__s': 'uniform_title', '787__r': 'report_number', '787__u': 'standard_technical_report_number', '787__t': 'title', '787__w': 'record_control_number', '787__y': 'coden_designation', '787__x': 'international_standard_serial_number', '787__z': 'international_standard_book_number'}
+        json_for_marc(), {'4': 'relationship_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'main_entry_heading', 'c': 'qualifying_information', 'b': 'edition', 'd': 'place_publisher_and_date_of_publication', 'g': 'related_parts', 'i': 'relationship_information', 'h': 'physical_description', 'k': 'series_data_for_related_item', 'm': 'material_specific_details', 'o': 'other_item_identifier', 'n': 'note', 's': 'uniform_title', 'r': 'report_number', 'u': 'standard_technical_report_number', 't': 'title', 'w': 'record_control_number', 'y': 'coden_designation', 'x': 'international_standard_serial_number', 'z': 'international_standard_book_number'}
 
 @extend
 series_added_entry_personal_name:
@@ -3628,7 +3628,7 @@ series_added_entry_personal_name:
                 ('800__x', 'international_standard_serial_number'))
         marc, '800..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'relator_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'personal_name': value['a'], 'titles_and_other_words_associated_with_a_name': value['c'], 'numeration': value['b'], 'relator_term': value['e'], 'dates_associated_with_a_name': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'attribution_qualifier': value['j'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'fuller_form_of_name': value['q'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'bibliographic_record_control_number': value['w'], 'volume_sequential_designation': value['v'], 'international_standard_serial_number': value['x']}
     producer:
-        json_for_marc(), {'800__0': 'authority_record_control_number', '800__3': 'materials_specified', '800__5': 'institution_to_which_field_applies', '800__4': 'relator_code', '800__7': 'control_subfield', '800__6': 'linkage', '800__8': 'field_link_and_sequence_number', '800__a': 'personal_name', '800__c': 'titles_and_other_words_associated_with_a_name', '800__b': 'numeration', '800__e': 'relator_term', '800__d': 'dates_associated_with_a_name', '800__g': 'miscellaneous_information', '800__f': 'date_of_a_work', '800__h': 'medium', '800__k': 'form_subheading', '800__j': 'attribution_qualifier', '800__m': 'medium_of_performance_for_music', '800__l': 'language_of_a_work', '800__o': 'arranged_statement_for_music', '800__n': 'number_of_part_section_of_a_work', '800__q': 'fuller_form_of_name', '800__p': 'name_of_part_section_of_a_work', '800__s': 'version', '800__r': 'key_for_music', '800__u': 'affiliation', '800__t': 'title_of_a_work', '800__w': 'bibliographic_record_control_number', '800__v': 'volume_sequential_designation', '800__x': 'international_standard_serial_number'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '4': 'relator_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'personal_name', 'c': 'titles_and_other_words_associated_with_a_name', 'b': 'numeration', 'e': 'relator_term', 'd': 'dates_associated_with_a_name', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'j': 'attribution_qualifier', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', 'q': 'fuller_form_of_name', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', 'u': 'affiliation', 't': 'title_of_a_work', 'w': 'bibliographic_record_control_number', 'v': 'volume_sequential_designation', 'x': 'international_standard_serial_number'}
 
 @extend
 series_added_entry_corporate_name:
@@ -3664,7 +3664,7 @@ series_added_entry_corporate_name:
                 ('810__x', 'international_standard_serial_number'))
         marc, '810..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'relator_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'corporate_name_or_jurisdiction_name_as_entry_element': value['a'], 'location_of_meeting': value['c'], 'subordinate_unit': value['b'], 'relator_term': value['e'], 'date_of_meeting_or_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_meeting': value['n'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'bibliographic_record_control_number': value['w'], 'volume_sequential_designation': value['v'], 'international_standard_serial_number': value['x']}
     producer:
-        json_for_marc(), {'810__0': 'authority_record_control_number', '810__3': 'materials_specified', '810__5': 'institution_to_which_field_applies', '810__4': 'relator_code', '810__7': 'control_subfield', '810__6': 'linkage', '810__8': 'field_link_and_sequence_number', '810__a': 'corporate_name_or_jurisdiction_name_as_entry_element', '810__c': 'location_of_meeting', '810__b': 'subordinate_unit', '810__e': 'relator_term', '810__d': 'date_of_meeting_or_treaty_signing', '810__g': 'miscellaneous_information', '810__f': 'date_of_a_work', '810__h': 'medium', '810__k': 'form_subheading', '810__m': 'medium_of_performance_for_music', '810__l': 'language_of_a_work', '810__o': 'arranged_statement_for_music', '810__n': 'number_of_part_section_meeting', '810__p': 'name_of_part_section_of_a_work', '810__s': 'version', '810__r': 'key_for_music', '810__u': 'affiliation', '810__t': 'title_of_a_work', '810__w': 'bibliographic_record_control_number', '810__v': 'volume_sequential_designation', '810__x': 'international_standard_serial_number'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '4': 'relator_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'corporate_name_or_jurisdiction_name_as_entry_element', 'c': 'location_of_meeting', 'b': 'subordinate_unit', 'e': 'relator_term', 'd': 'date_of_meeting_or_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_meeting', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', 'u': 'affiliation', 't': 'title_of_a_work', 'w': 'bibliographic_record_control_number', 'v': 'volume_sequential_designation', 'x': 'international_standard_serial_number'}
 
 @extend
 series_added_entry_meeting_name:
@@ -3698,7 +3698,7 @@ series_added_entry_meeting_name:
                 ('811__x', 'international_standard_serial_number'))
         marc, '811..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'relator_code': value['4'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'meeting_name_or_jurisdiction_name_as_entry_element': value['a'], 'location_of_meeting': value['c'], 'subordinate_unit': value['e'], 'date_of_meeting': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'relator_term': value['j'], 'language_of_a_work': value['l'], 'number_of_part_section_meeting': value['n'], 'name_of_meeting_following_jurisdiction_name_entry_element': value['q'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'affiliation': value['u'], 'title_of_a_work': value['t'], 'bibliographic_record_control_number': value['w'], 'volume_sequential_designation': value['v'], 'international_standard_serial_number': value['x']}
     producer:
-        json_for_marc(), {'811__0': 'authority_record_control_number', '811__3': 'materials_specified', '811__5': 'institution_to_which_field_applies', '811__4': 'relator_code', '811__7': 'control_subfield', '811__6': 'linkage', '811__8': 'field_link_and_sequence_number', '811__a': 'meeting_name_or_jurisdiction_name_as_entry_element', '811__c': 'location_of_meeting', '811__e': 'subordinate_unit', '811__d': 'date_of_meeting', '811__g': 'miscellaneous_information', '811__f': 'date_of_a_work', '811__h': 'medium', '811__k': 'form_subheading', '811__j': 'relator_term', '811__l': 'language_of_a_work', '811__n': 'number_of_part_section_meeting', '811__q': 'name_of_meeting_following_jurisdiction_name_entry_element', '811__p': 'name_of_part_section_of_a_work', '811__s': 'version', '811__u': 'affiliation', '811__t': 'title_of_a_work', '811__w': 'bibliographic_record_control_number', '811__v': 'volume_sequential_designation', '811__x': 'international_standard_serial_number'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '4': 'relator_code', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'meeting_name_or_jurisdiction_name_as_entry_element', 'c': 'location_of_meeting', 'e': 'subordinate_unit', 'd': 'date_of_meeting', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'j': 'relator_term', 'l': 'language_of_a_work', 'n': 'number_of_part_section_meeting', 'q': 'name_of_meeting_following_jurisdiction_name_entry_element', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'u': 'affiliation', 't': 'title_of_a_work', 'w': 'bibliographic_record_control_number', 'v': 'volume_sequential_designation', 'x': 'international_standard_serial_number'}
 
 @extend
 series_added_entry_uniform_title:
@@ -3729,7 +3729,7 @@ series_added_entry_uniform_title:
                 ('830__x', 'international_standard_serial_number'))
         marc, '830..', {'authority_record_control_number': value['0'], 'materials_specified': value['3'], 'institution_to_which_field_applies': value['5'], 'control_subfield': value['7'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'uniform_title': value['a'], 'date_of_treaty_signing': value['d'], 'miscellaneous_information': value['g'], 'date_of_a_work': value['f'], 'medium': value['h'], 'form_subheading': value['k'], 'medium_of_performance_for_music': value['m'], 'language_of_a_work': value['l'], 'arranged_statement_for_music': value['o'], 'number_of_part_section_of_a_work': value['n'], 'name_of_part_section_of_a_work': value['p'], 'version': value['s'], 'key_for_music': value['r'], 'title_of_a_work': value['t'], 'bibliographic_record_control_number': value['w'], 'volume_sequential_designation': value['v'], 'international_standard_serial_number': value['x']}
     producer:
-        json_for_marc(), {'830__0': 'authority_record_control_number', '830__3': 'materials_specified', '830__5': 'institution_to_which_field_applies', '830__7': 'control_subfield', '830__6': 'linkage', '830__8': 'field_link_and_sequence_number', '830__a': 'uniform_title', '830__d': 'date_of_treaty_signing', '830__g': 'miscellaneous_information', '830__f': 'date_of_a_work', '830__h': 'medium', '830__k': 'form_subheading', '830__m': 'medium_of_performance_for_music', '830__l': 'language_of_a_work', '830__o': 'arranged_statement_for_music', '830__n': 'number_of_part_section_of_a_work', '830__p': 'name_of_part_section_of_a_work', '830__s': 'version', '830__r': 'key_for_music', '830__t': 'title_of_a_work', '830__w': 'bibliographic_record_control_number', '830__v': 'volume_sequential_designation', '830__x': 'international_standard_serial_number'}
+        json_for_marc(), {'0': 'authority_record_control_number', '3': 'materials_specified', '5': 'institution_to_which_field_applies', '7': 'control_subfield', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'uniform_title', 'd': 'date_of_treaty_signing', 'g': 'miscellaneous_information', 'f': 'date_of_a_work', 'h': 'medium', 'k': 'form_subheading', 'm': 'medium_of_performance_for_music', 'l': 'language_of_a_work', 'o': 'arranged_statement_for_music', 'n': 'number_of_part_section_of_a_work', 'p': 'name_of_part_section_of_a_work', 's': 'version', 'r': 'key_for_music', 't': 'title_of_a_work', 'w': 'bibliographic_record_control_number', 'v': 'volume_sequential_designation', 'x': 'international_standard_serial_number'}
 
 @extend
 holding_institution:
@@ -3739,7 +3739,7 @@ holding_institution:
                 ('850__8', 'field_link_and_sequence_number'))
         marc, '850..', {'holding_institution': value['a'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'850__a': 'holding_institution', '850__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'holding_institution', '8': 'field_link_and_sequence_number'}
 
 @extend
 location:
@@ -3772,7 +3772,7 @@ location:
                 ('852__z', 'public_note'))
         marc, '852..', {'materials_specified': value['3'], 'source_of_classification_or_shelving_scheme': value['2'], 'linkage': value['6'], 'sequence_number': value['8'], 'location': value['a'], 'shelving_location': value['c'], 'sublocation_or_collection': value['b'], 'address': value['e'], 'former_shelving_location': value['d'], 'non_coded_location_qualifier': value['g'], 'coded_location_qualifier': value['f'], 'item_part': value['i'], 'classification_part': value['h'], 'call_number_prefix': value['k'], 'shelving_control_number': value['j'], 'call_number_suffix': value['m'], 'shelving_form_of_title': value['l'], 'country_code': value['n'], 'piece_physical_condition': value['q'], 'piece_designation': value['p'], 'copyright_article_fee_code': value['s'], 'uniform_resource_identifier': value['u'], 'copy_number': value['t'], 'nonpublic_note': value['x'], 'public_note': value['z']}
     producer:
-        json_for_marc(), {'852__3': 'materials_specified', '852__2': 'source_of_classification_or_shelving_scheme', '852__6': 'linkage', '852__8': 'sequence_number', '852__a': 'location', '852__c': 'shelving_location', '852__b': 'sublocation_or_collection', '852__e': 'address', '852__d': 'former_shelving_location', '852__g': 'non_coded_location_qualifier', '852__f': 'coded_location_qualifier', '852__i': 'item_part', '852__h': 'classification_part', '852__k': 'call_number_prefix', '852__j': 'shelving_control_number', '852__m': 'call_number_suffix', '852__l': 'shelving_form_of_title', '852__n': 'country_code', '852__q': 'piece_physical_condition', '852__p': 'piece_designation', '852__s': 'copyright_article_fee_code', '852__u': 'uniform_resource_identifier', '852__t': 'copy_number', '852__x': 'nonpublic_note', '852__z': 'public_note'}
+        json_for_marc(), {'3': 'materials_specified', '2': 'source_of_classification_or_shelving_scheme', '6': 'linkage', '8': 'sequence_number', 'a': 'location', 'c': 'shelving_location', 'b': 'sublocation_or_collection', 'e': 'address', 'd': 'former_shelving_location', 'g': 'non_coded_location_qualifier', 'f': 'coded_location_qualifier', 'i': 'item_part', 'h': 'classification_part', 'k': 'call_number_prefix', 'j': 'shelving_control_number', 'm': 'call_number_suffix', 'l': 'shelving_form_of_title', 'n': 'country_code', 'q': 'piece_physical_condition', 'p': 'piece_designation', 's': 'copyright_article_fee_code', 'u': 'uniform_resource_identifier', 't': 'copy_number', 'x': 'nonpublic_note', 'z': 'public_note'}
 
 @extend
 electronic_location_and_access:
@@ -3808,7 +3808,7 @@ electronic_location_and_access:
                 ('856__z', 'public_note'))
         marc, '856..', {'materials_specified': value['3'], 'access_method': value['2'], 'linkage': value['6'], 'field_link_and_sequence_number': value['8'], 'host_name': value['a'], 'compression_information': value['c'], 'access_number': value['b'], 'path': value['d'], 'electronic_name': value['f'], 'instruction': value['i'], 'processor_of_request': value['h'], 'password': value['k'], 'bits_per_second': value['j'], 'contact_for_access_assistance': value['m'], 'logon': value['l'], 'operating_system': value['o'], 'name_of_location_of_host': value['n'], 'electronic_format_type': value['q'], 'port': value['p'], 'file_size': value['s'], 'settings': value['r'], 'uniform_resource_identifier': value['u'], 'terminal_emulation': value['t'], 'record_control_number': value['w'], 'hours_access_method_available': value['v'], 'link_text': value['y'], 'nonpublic_note': value['x'], 'public_note': value['z']}
     producer:
-        json_for_marc(), {'856__3': 'materials_specified', '856__2': 'access_method', '856__6': 'linkage', '856__8': 'field_link_and_sequence_number', '856__a': 'host_name', '856__c': 'compression_information', '856__b': 'access_number', '856__d': 'path', '856__f': 'electronic_name', '856__i': 'instruction', '856__h': 'processor_of_request', '856__k': 'password', '856__j': 'bits_per_second', '856__m': 'contact_for_access_assistance', '856__l': 'logon', '856__o': 'operating_system', '856__n': 'name_of_location_of_host', '856__q': 'electronic_format_type', '856__p': 'port', '856__s': 'file_size', '856__r': 'settings', '856__u': 'uniform_resource_identifier', '856__t': 'terminal_emulation', '856__w': 'record_control_number', '856__v': 'hours_access_method_available', '856__y': 'link_text', '856__x': 'nonpublic_note', '856__z': 'public_note'}
+        json_for_marc(), {'3': 'materials_specified', '2': 'access_method', '6': 'linkage', '8': 'field_link_and_sequence_number', 'a': 'host_name', 'c': 'compression_information', 'b': 'access_number', 'd': 'path', 'f': 'electronic_name', 'i': 'instruction', 'h': 'processor_of_request', 'k': 'password', 'j': 'bits_per_second', 'm': 'contact_for_access_assistance', 'l': 'logon', 'o': 'operating_system', 'n': 'name_of_location_of_host', 'q': 'electronic_format_type', 'p': 'port', 's': 'file_size', 'r': 'settings', 'u': 'uniform_resource_identifier', 't': 'terminal_emulation', 'w': 'record_control_number', 'v': 'hours_access_method_available', 'y': 'link_text', 'x': 'nonpublic_note', 'z': 'public_note'}
 
 @extend
 alternate_graphic_representation:
@@ -3852,7 +3852,7 @@ alternate_graphic_representation:
                 ('880__z', 'same_as_associated_field'))
         marc, '880..', {'same_as_associated_field': value['1'], 'same_as_associated_field': value['0'], 'same_as_associated_field': value['3'], 'same_as_associated_field': value['2'], 'same_as_associated_field': value['5'], 'same_as_associated_field': value['4'], 'same_as_associated_field': value['7'], 'linkage': value['6'], 'same_as_associated_field': value['9'], 'same_as_associated_field': value['8'], 'same_as_associated_field': value['a'], 'same_as_associated_field': value['c'], 'same_as_associated_field': value['b'], 'same_as_associated_field': value['e'], 'same_as_associated_field': value['d'], 'same_as_associated_field': value['g'], 'same_as_associated_field': value['f'], 'same_as_associated_field': value['i'], 'same_as_associated_field': value['h'], 'same_as_associated_field': value['k'], 'same_as_associated_field': value['j'], 'same_as_associated_field': value['m'], 'same_as_associated_field': value['l'], 'same_as_associated_field': value['o'], 'same_as_associated_field': value['n'], 'same_as_associated_field': value['q'], 'same_as_associated_field': value['p'], 'same_as_associated_field': value['s'], 'same_as_associated_field': value['r'], 'same_as_associated_field': value['u'], 'same_as_associated_field': value['t'], 'same_as_associated_field': value['w'], 'same_as_associated_field': value['v'], 'same_as_associated_field': value['y'], 'same_as_associated_field': value['x'], 'same_as_associated_field': value['z']}
     producer:
-        json_for_marc(), {'880__1': 'same_as_associated_field', '880__0': 'same_as_associated_field', '880__3': 'same_as_associated_field', '880__2': 'same_as_associated_field', '880__5': 'same_as_associated_field', '880__4': 'same_as_associated_field', '880__7': 'same_as_associated_field', '880__6': 'linkage', '880__9': 'same_as_associated_field', '880__8': 'same_as_associated_field', '880__a': 'same_as_associated_field', '880__c': 'same_as_associated_field', '880__b': 'same_as_associated_field', '880__e': 'same_as_associated_field', '880__d': 'same_as_associated_field', '880__g': 'same_as_associated_field', '880__f': 'same_as_associated_field', '880__i': 'same_as_associated_field', '880__h': 'same_as_associated_field', '880__k': 'same_as_associated_field', '880__j': 'same_as_associated_field', '880__m': 'same_as_associated_field', '880__l': 'same_as_associated_field', '880__o': 'same_as_associated_field', '880__n': 'same_as_associated_field', '880__q': 'same_as_associated_field', '880__p': 'same_as_associated_field', '880__s': 'same_as_associated_field', '880__r': 'same_as_associated_field', '880__u': 'same_as_associated_field', '880__t': 'same_as_associated_field', '880__w': 'same_as_associated_field', '880__v': 'same_as_associated_field', '880__y': 'same_as_associated_field', '880__x': 'same_as_associated_field', '880__z': 'same_as_associated_field'}
+        json_for_marc(), {'1': 'same_as_associated_field', '0': 'same_as_associated_field', '3': 'same_as_associated_field', '2': 'same_as_associated_field', '5': 'same_as_associated_field', '4': 'same_as_associated_field', '7': 'same_as_associated_field', '6': 'linkage', '9': 'same_as_associated_field', '8': 'same_as_associated_field', 'a': 'same_as_associated_field', 'c': 'same_as_associated_field', 'b': 'same_as_associated_field', 'e': 'same_as_associated_field', 'd': 'same_as_associated_field', 'g': 'same_as_associated_field', 'f': 'same_as_associated_field', 'i': 'same_as_associated_field', 'h': 'same_as_associated_field', 'k': 'same_as_associated_field', 'j': 'same_as_associated_field', 'm': 'same_as_associated_field', 'l': 'same_as_associated_field', 'o': 'same_as_associated_field', 'n': 'same_as_associated_field', 'q': 'same_as_associated_field', 'p': 'same_as_associated_field', 's': 'same_as_associated_field', 'r': 'same_as_associated_field', 'u': 'same_as_associated_field', 't': 'same_as_associated_field', 'w': 'same_as_associated_field', 'v': 'same_as_associated_field', 'y': 'same_as_associated_field', 'x': 'same_as_associated_field', 'z': 'same_as_associated_field'}
 
 @extend
 replacement_record_information:
@@ -3865,7 +3865,7 @@ replacement_record_information:
                 ('882__6', 'linkage'))
         marc, '882..', {'replacement_title': value['a'], 'field_link_and_sequence_number': value['8'], 'explanatory_text': value['i'], 'replacement_bibliographic_record_control_number': value['w'], 'linkage': value['6']}
     producer:
-        json_for_marc(), {'882__a': 'replacement_title', '882__8': 'field_link_and_sequence_number', '882__i': 'explanatory_text', '882__w': 'replacement_bibliographic_record_control_number', '882__6': 'linkage'}
+        json_for_marc(), {'a': 'replacement_title', '8': 'field_link_and_sequence_number', 'i': 'explanatory_text', 'w': 'replacement_bibliographic_record_control_number', '6': 'linkage'}
 
 @extend
 machine_generated_metadata_provenance:
@@ -3882,7 +3882,7 @@ machine_generated_metadata_provenance:
                 ('883__8', 'field_link_and_sequence_number'))
         marc, '883..', {'generation_process': value['a'], 'confidence_value': value['c'], 'generation_date': value['d'], 'generation_agency': value['q'], 'authority_record_control_number_or_standard_number': value['0'], 'uniform_resource_identifier': value['u'], 'bibliographic_record_control_number': value['w'], 'validity_end_date': value['x'], 'field_link_and_sequence_number': value['8']}
     producer:
-        json_for_marc(), {'883__a': 'generation_process', '883__c': 'confidence_value', '883__d': 'generation_date', '883__q': 'generation_agency', '883__0': 'authority_record_control_number_or_standard_number', '883__u': 'uniform_resource_identifier', '883__w': 'bibliographic_record_control_number', '883__x': 'validity_end_date', '883__8': 'field_link_and_sequence_number'}
+        json_for_marc(), {'a': 'generation_process', 'c': 'confidence_value', 'd': 'generation_date', 'q': 'generation_agency', '0': 'authority_record_control_number_or_standard_number', 'u': 'uniform_resource_identifier', 'w': 'bibliographic_record_control_number', 'x': 'validity_end_date', '8': 'field_link_and_sequence_number'}
 
 @extend
 foreign_marc_information_field:
@@ -3926,7 +3926,7 @@ foreign_marc_information_field:
                 ('886__z', 'foreign_marc_subfield'))
         marc, '886..', {'foreign_marc_subfield': value['1'], 'foreign_marc_subfield': value['0'], 'foreign_marc_subfield': value['3'], 'foreign_marc_subfield': value['2'], 'foreign_marc_subfield': value['5'], 'foreign_marc_subfield': value['4'], 'foreign_marc_subfield': value['7'], 'foreign_marc_subfield': value['6'], 'foreign_marc_subfield': value['9'], 'foreign_marc_subfield': value['8'], 'foreign_marc_subfield': value['a'], 'foreign_marc_subfield': value['c'], 'foreign_marc_subfield': value['b'], 'foreign_marc_subfield': value['e'], 'foreign_marc_subfield': value['d'], 'foreign_marc_subfield': value['g'], 'foreign_marc_subfield': value['f'], 'foreign_marc_subfield': value['i'], 'foreign_marc_subfield': value['h'], 'foreign_marc_subfield': value['k'], 'foreign_marc_subfield': value['j'], 'foreign_marc_subfield': value['m'], 'foreign_marc_subfield': value['l'], 'foreign_marc_subfield': value['o'], 'foreign_marc_subfield': value['n'], 'foreign_marc_subfield': value['q'], 'foreign_marc_subfield': value['p'], 'foreign_marc_subfield': value['s'], 'foreign_marc_subfield': value['r'], 'foreign_marc_subfield': value['u'], 'foreign_marc_subfield': value['t'], 'foreign_marc_subfield': value['w'], 'foreign_marc_subfield': value['v'], 'foreign_marc_subfield': value['y'], 'foreign_marc_subfield': value['x'], 'foreign_marc_subfield': value['z']}
     producer:
-        json_for_marc(), {'886__1': 'foreign_marc_subfield', '886__0': 'foreign_marc_subfield', '886__3': 'foreign_marc_subfield', '886__2': 'foreign_marc_subfield', '886__5': 'foreign_marc_subfield', '886__4': 'foreign_marc_subfield', '886__7': 'foreign_marc_subfield', '886__6': 'foreign_marc_subfield', '886__9': 'foreign_marc_subfield', '886__8': 'foreign_marc_subfield', '886__a': 'foreign_marc_subfield', '886__c': 'foreign_marc_subfield', '886__b': 'foreign_marc_subfield', '886__e': 'foreign_marc_subfield', '886__d': 'foreign_marc_subfield', '886__g': 'foreign_marc_subfield', '886__f': 'foreign_marc_subfield', '886__i': 'foreign_marc_subfield', '886__h': 'foreign_marc_subfield', '886__k': 'foreign_marc_subfield', '886__j': 'foreign_marc_subfield', '886__m': 'foreign_marc_subfield', '886__l': 'foreign_marc_subfield', '886__o': 'foreign_marc_subfield', '886__n': 'foreign_marc_subfield', '886__q': 'foreign_marc_subfield', '886__p': 'foreign_marc_subfield', '886__s': 'foreign_marc_subfield', '886__r': 'foreign_marc_subfield', '886__u': 'foreign_marc_subfield', '886__t': 'foreign_marc_subfield', '886__w': 'foreign_marc_subfield', '886__v': 'foreign_marc_subfield', '886__y': 'foreign_marc_subfield', '886__x': 'foreign_marc_subfield', '886__z': 'foreign_marc_subfield'}
+        json_for_marc(), {'1': 'foreign_marc_subfield', '0': 'foreign_marc_subfield', '3': 'foreign_marc_subfield', '2': 'foreign_marc_subfield', '5': 'foreign_marc_subfield', '4': 'foreign_marc_subfield', '7': 'foreign_marc_subfield', '6': 'foreign_marc_subfield', '9': 'foreign_marc_subfield', '8': 'foreign_marc_subfield', 'a': 'foreign_marc_subfield', 'c': 'foreign_marc_subfield', 'b': 'foreign_marc_subfield', 'e': 'foreign_marc_subfield', 'd': 'foreign_marc_subfield', 'g': 'foreign_marc_subfield', 'f': 'foreign_marc_subfield', 'i': 'foreign_marc_subfield', 'h': 'foreign_marc_subfield', 'k': 'foreign_marc_subfield', 'j': 'foreign_marc_subfield', 'm': 'foreign_marc_subfield', 'l': 'foreign_marc_subfield', 'o': 'foreign_marc_subfield', 'n': 'foreign_marc_subfield', 'q': 'foreign_marc_subfield', 'p': 'foreign_marc_subfield', 's': 'foreign_marc_subfield', 'r': 'foreign_marc_subfield', 'u': 'foreign_marc_subfield', 't': 'foreign_marc_subfield', 'w': 'foreign_marc_subfield', 'v': 'foreign_marc_subfield', 'y': 'foreign_marc_subfield', 'x': 'foreign_marc_subfield', 'z': 'foreign_marc_subfield'}
 
 @extend
 non_marc_information_field:
@@ -3936,4 +3936,4 @@ non_marc_information_field:
                 ('887__2', 'source_of_data'))
         marc, '887..', {'content_of_non_marc_field': value['a'], 'source_of_data': value['2']}
     producer:
-        json_for_marc(), {'887__a': 'content_of_non_marc_field', '887__2': 'source_of_data'}
+        json_for_marc(), {'a': 'content_of_non_marc_field', '2': 'source_of_data'}

--- a/jsonalchemy/wrappers.py
+++ b/jsonalchemy/wrappers.py
@@ -146,8 +146,8 @@ class SmartDict(object):
         return True
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__)
-                and self._dict == other._dict)
+        return (isinstance(other, self.__class__) and
+                self._dict == other._dict)
 
     def __iter__(self):
         return iter(self._dict)
@@ -444,8 +444,8 @@ class SmartJson(SmartDict):
             except IndexError:
                 rest_of_key = ''
             return self[
-                self._dict['__meta_metadata__']['__aliases__'][main_key]
-                + rest_of_key]
+                self._dict['__meta_metadata__']['__aliases__'][main_key] +
+                rest_of_key]
 
     def __setitem__(self, key, value, extend=False, **kwargs):
         """Like in `dict.__setitem__`.


### PR DESCRIPTION
- Amends producer rules so that input MARC tag indicators would be
  respected.  (closes #3)

Reported-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
Signed-off-by: Tibor Simko tibor.simko@cern.ch
