### PR TITLE
tests: lint JSON fixtures

### DIFF
--- a/tests/schemas/complex.json
+++ b/tests/schemas/complex.json
@@ -1,17 +1,23 @@
 {
-	"title": "Test complex schema",
-	"type": "object",
-	"properties": {
-		"authors": {
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"given_name": { "type": "string" },
-					"family_name": { "type": "string" },
-					"affiliation": { "type": "string" }
-				} 
-			}
-		}
-	}
+    "title": "Test complex schema",
+    "type": "object",
+    "properties": {
+        "authors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "given_name": {
+                        "type": "string"
+                    },
+                    "family_name": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
 }

--- a/tests/schemas/compose/author.json
+++ b/tests/schemas/compose/author.json
@@ -1,4 +1,4 @@
 {
-	"title": "Author compose fixture",
-	"type": "string"
+    "title": "Author compose fixture",
+    "type": "string"
 }

--- a/tests/schemas/compose/title.json
+++ b/tests/schemas/compose/title.json
@@ -1,4 +1,4 @@
 {
-	"title": "Title compose fixture",
-	"type": "string"
+    "title": "Title compose fixture",
+    "type": "string"
 }

--- a/tests/schemas/creation_date.json
+++ b/tests/schemas/creation_date.json
@@ -1,10 +1,10 @@
 {
-	"title": "Test creation date schema",
-	"type": "object",
-	"properties": {
-		"creation_date": {
-			"type": "string",
-			"format": "date"
-		}
-	}
+    "title": "Test creation date schema",
+    "type": "object",
+    "properties": {
+        "creation_date": {
+            "type": "string",
+            "format": "date"
+        }
+    }
 }

--- a/tests/schemas/inherit/base.json
+++ b/tests/schemas/inherit/base.json
@@ -1,8 +1,12 @@
 {
-	"title": "Base inheritance schema",
-	"type": "object",
-	"properties": {
-	    "title": { "type": "string" },
-	    "author": { "type": "string" }
-	}
+    "title": "Base inheritance schema",
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "author": {
+            "type": "string"
+        }
+    }
 }

--- a/tests/schemas/inherit/title.json
+++ b/tests/schemas/inherit/title.json
@@ -1,13 +1,17 @@
 {
-	"title": "Title schema",
-	"type": "object",
-	"properties": {
-	    "title": { 
-	    	"type": "object",
-	    	"properties": {
-	    		"name": { "type": "string" },
-	    		"subtitle": { "type": "string" }
-	    	}
-	     },
-	}
+    "title": "Title schema",
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "subtitle": {
+                    "type": "string"
+                }
+            }
+        }
+    }
 }

--- a/tests/schemas/invalid_json_schema.json
+++ b/tests/schemas/invalid_json_schema.json
@@ -1,9 +1,9 @@
 {
-	"title": "Test simple schema",
-	"type": "object",
-	"properties": {
-		"my_field": {
-			"type": "nonvalidtype"
-		}
-	}
+    "title": "Test simple schema",
+    "type": "object",
+    "properties": {
+        "my_field": {
+            "type": "nonvalidtype"
+        }
+    }
 }

--- a/tests/schemas/mixin/author.json
+++ b/tests/schemas/mixin/author.json
@@ -1,9 +1,9 @@
 {
-	"title": "Test author schema",
-	"type": "object",
-	"properties": {
-		"author": {
-			"type": "string"
-		}
-	}
+    "title": "Test author schema",
+    "type": "object",
+    "properties": {
+        "author": {
+            "type": "string"
+        }
+    }
 }

--- a/tests/schemas/mixin/authors.json
+++ b/tests/schemas/mixin/authors.json
@@ -4,12 +4,18 @@
     "properties": {
         "authors": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+                "type": "string"
+            }
         },
-        "author": { "type": "string" },
+        "author": {
+            "type": "string"
+        },
         "other_authors": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/tests/schemas/mixin/keywords.json
+++ b/tests/schemas/mixin/keywords.json
@@ -4,12 +4,18 @@
     "properties": {
         "keywords": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+                "type": "string"
+            }
         },
-        "first_keyword": { "type": "string" },
+        "first_keyword": {
+            "type": "string"
+        },
         "other_keywords": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/tests/schemas/mixin/title.json
+++ b/tests/schemas/mixin/title.json
@@ -1,8 +1,8 @@
 {
-	"type": "object",
-	"properties": {
-	    "title": {
-	    	"type": "string"
-	    }
-	}
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string"
+        }
+    }
 }

--- a/tests/schemas/record_with_title.json
+++ b/tests/schemas/record_with_title.json
@@ -1,9 +1,9 @@
 {
-	"title": "Record with a title",
-        "type": "object",
-	"properties": {
-	    "title": {
-	    	"$ref": "title.json#/#title"
-	    }
-	}
+    "title": "Record with a title",
+    "type": "object",
+    "properties": {
+        "title": {
+            "$ref": "title.json#/#title"
+        }
+    }
 }

--- a/tests/schemas/simple.json
+++ b/tests/schemas/simple.json
@@ -1,9 +1,9 @@
 {
-	"title": "Test simple schema",
-	"type": "object",
-	"properties": {
-		"my_field": {
-			"type": "string"
-		}
-	}
+    "title": "Test simple schema",
+    "type": "object",
+    "properties": {
+        "my_field": {
+            "type": "string"
+        }
+    }
 }

--- a/tests/schemas/title.json
+++ b/tests/schemas/title.json
@@ -1,9 +1,9 @@
 {
-	"id": "#title",
-  "type": "object",
-	"properties": {
-    "title": {
-      "type": "string"
+    "id": "#title",
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string"
+        }
     }
-	}
 }


### PR DESCRIPTION
Following https://github.com/inveniosoftware/jsonalchemy/commit/8e2ed25838eb89e0b798288c37d477f5c41edf95#commitcomment-10774827, here's the linted version of all JSON fixtures. These were obtained by running `find tests/schemas/ -name "*.json" -exec jsonlint -i -t "    " {} \;` using [zaach/jsonlint](https://github.com/zaach/jsonlint).
