### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,10 +24,10 @@ Authors
 =======
 
 JSONAlchemy is developed for the `Invenio
-<http://invenio-software.org>`_ digital library software.
+<http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org
-<mailto:info@invenio-software.org>`_.
+Contact us at `info@inveniosoftware.org
+<mailto:info@inveniosoftware.org>`_.
 
 - Esteban J. G. Gabancho <esteban.jose.garcia.gabancho@cern.ch>
 - Jiri Kuncar <jiri.kuncar@cern.ch>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -31,7 +31,7 @@ Documentation
 Good luck and thanks for using JSONAlchemy.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/jsonalchemy

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     url='https://github.com/inveniosoftware/jsonalchemy',
     license='GPLv2',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description=__doc__.split('\n')[0],
     long_description=__doc__,
     packages=find_packages(exclude=['tests', 'docs']),

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -164,11 +164,11 @@ class TestMarcReader(TestCase):
                 <subfield code="f">neil.calder@cern.ch</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/0106015_01.jpg</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/0106015_01.jpg</subfield>
                 <subfield code="r">restricted_picture</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/0106015_01.gif</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/0106015_01.gif</subfield>
                 <subfield code="f">.gif;icon</subfield>
                 <subfield code="r">restricted_picture</subfield>
                 </datafield>
@@ -263,26 +263,26 @@ class TestMarcReader(TestCase):
                 <subfield code="f">George Efstathiou &lt;gpe@ast.cam.ac.uk&gt;</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.pdf</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.pdf</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig1.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig1.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig3.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig3.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig5.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig5.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig6.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig6.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig7.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig7.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="909" ind1="C" ind2="0">
@@ -612,26 +612,26 @@ class TestMarcReader(TestCase):
                 <subfield code="f">George Efstathiou &lt;gpe@ast.cam.ac.uk&gt;</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.pdf</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.pdf</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig1.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig1.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig3.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig3.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig5.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig5.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig6.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig6.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="FFT" ind1=" " ind2=" ">
-                <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/9812226.fig7.ps.gz</subfield>
+                <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/9812226.fig7.ps.gz</subfield>
                 <subfield code="t">Additional</subfield>
                 </datafield>
                 <datafield tag="909" ind1="C" ind2="0">
@@ -1001,11 +1001,11 @@ class TestMarcReader(TestCase):
               <subfield code="f">neil.calder@cern.ch</subfield>
             </datafield>
             <datafield tag="FFT" ind1=" " ind2=" ">
-              <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/0106015_01.jpg</subfield>
+              <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/0106015_01.jpg</subfield>
               <subfield code="r">restricted_picture</subfield>
             </datafield>
             <datafield tag="FFT" ind1=" " ind2=" ">
-              <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/0106015_01.gif</subfield>
+              <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/0106015_01.gif</subfield>
               <subfield code="f">.gif;icon</subfield>
               <subfield code="r">restricted_picture</subfield>
             </datafield>
@@ -1090,11 +1090,11 @@ class TestMarcReader(TestCase):
               <subfield code="f">neil.calder@cern.ch</subfield>
             </datafield>
             <datafield tag="FFT" ind1=" " ind2=" ">
-              <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/0106015_01.jpg</subfield>
+              <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/0106015_01.jpg</subfield>
               <subfield code="r">restricted_picture</subfield>
             </datafield>
             <datafield tag="FFT" ind1=" " ind2=" ">
-              <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/0106015_01.gif</subfield>
+              <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/0106015_01.gif</subfield>
               <subfield code="f">.gif;icon</subfield>
               <subfield code="r">restricted_picture</subfield>
             </datafield>
@@ -1181,11 +1181,11 @@ class TestMarcReader(TestCase):
               <subfield code="f">neil.calder@cern.ch</subfield>
             </datafield>
             <datafield tag="FFT" ind1=" " ind2=" ">
-              <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/0106015_01.jpg</subfield>
+              <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/0106015_01.jpg</subfield>
               <subfield code="r">restricted_picture</subfield>
             </datafield>
             <datafield tag="FFT" ind1=" " ind2=" ">
-              <subfield code="a">http://invenio-software.org/download/invenio-demo-site-files/0106015_01.gif</subfield>
+              <subfield code="a">http://inveniosoftware.org/download/invenio-demo-site-files/0106015_01.gif</subfield>
               <subfield code="f">.gif;icon</subfield>
               <subfield code="r">restricted_picture</subfield>
             </datafield>


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
